### PR TITLE
feat: add linting engine and check command

### DIFF
--- a/packages/north/src/cli/index.ts
+++ b/packages/north/src/cli/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
+import { check } from "../commands/check.ts";
 import { doctor } from "../commands/doctor.ts";
 import { generateTokens } from "../commands/gen.ts";
 import { init } from "../commands/init.ts";
@@ -62,9 +63,34 @@ program
 program
   .command("doctor")
   .description("Validate North setup and configuration")
-  .action(async () => {
+  .option("--lint", "Run lint diagnostics (rules + extraction coverage)")
+  .action(async (options) => {
     const result = await doctor({
       cwd: process.cwd(),
+      lint: options.lint,
+    });
+
+    if (!result.success) {
+      process.exit(1);
+    }
+  });
+
+// ============================================================================
+// check - Lint for design system violations
+// ============================================================================
+
+program
+  .command("check")
+  .description("Lint for design system violations")
+  .option("-c, --config <path>", "Path to config file")
+  .option("--json", "Output JSON report")
+  .option("--staged", "Only lint staged files")
+  .action(async (options) => {
+    const result = await check({
+      cwd: process.cwd(),
+      config: options.config,
+      json: options.json,
+      staged: options.staged,
     });
 
     if (!result.success) {

--- a/packages/north/src/commands/check.ts
+++ b/packages/north/src/commands/check.ts
@@ -1,0 +1,115 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import chalk from "chalk";
+import { runLint } from "../lint/engine.ts";
+import { formatLintReport } from "../lint/format.ts";
+
+// ============================================================================
+// Error Types
+// ============================================================================
+
+export class CheckError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = "CheckError";
+  }
+}
+
+// ============================================================================
+// Check Command
+// ============================================================================
+
+export interface CheckOptions {
+  cwd?: string;
+  config?: string;
+  json?: boolean;
+  staged?: boolean;
+}
+
+export interface CheckResult {
+  success: boolean;
+  message: string;
+  error?: Error;
+}
+
+function getStagedFiles(cwd: string): string[] {
+  const result = spawnSync("git", ["diff", "--name-only", "--cached", "--diff-filter=ACMR"], {
+    cwd,
+    encoding: "utf-8",
+  });
+
+  if (result.error) {
+    throw new CheckError("Failed to determine staged files", result.error);
+  }
+
+  if (result.status !== 0) {
+    throw new CheckError(`Git diff failed: ${result.stderr}`);
+  }
+
+  return result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((file) => resolve(cwd, file))
+    .filter((file) => file.endsWith(".tsx") || file.endsWith(".jsx"));
+}
+
+export async function check(options: CheckOptions = {}): Promise<CheckResult> {
+  const cwd = options.cwd ?? process.cwd();
+
+  try {
+    const files = options.staged ? getStagedFiles(cwd) : undefined;
+
+    if (options.staged && files && files.length === 0) {
+      if (!options.json) {
+        console.log(chalk.yellow("No staged TSX/JSX files to lint."));
+      }
+      return { success: true, message: "No staged files" };
+    }
+
+    const { report } = await runLint({
+      cwd,
+      configPath: options.config,
+      files,
+    });
+
+    if (options.json) {
+      const serializableReport = {
+        summary: report.summary,
+        violations: report.issues,
+        stats: report.stats,
+        rules: report.rules.map((rule) => ({
+          ...rule,
+          regex: rule.regex ? rule.regex.source : undefined,
+        })),
+      };
+
+      console.log(JSON.stringify(serializableReport, null, 2));
+    } else {
+      console.log(formatLintReport(report));
+    }
+
+    const hasErrors = report.summary.errors > 0;
+
+    return {
+      success: !hasErrors,
+      message: hasErrors ? "Lint errors found" : "Lint passed",
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    if (!options.json) {
+      console.log(chalk.red("\n✗ Lint failed"));
+      console.log(chalk.dim(errorMessage));
+    }
+
+    return {
+      success: false,
+      message: `Lint failed: ${errorMessage}`,
+      error: error instanceof Error ? error : new CheckError(errorMessage),
+    };
+  }
+}

--- a/packages/north/src/config/defaults.ts
+++ b/packages/north/src/config/defaults.ts
@@ -163,6 +163,10 @@ rules:
     level: info
     promote-threshold: 3
 
+# Lint configuration (optional)
+# lint:
+#   classFunctions: [cn, clsx, cva]
+
 # Third-party component policy
 third-party:
   allowed:
@@ -202,5 +206,6 @@ export function applyDefaults(config: Partial<NorthConfig>): NorthConfig {
     rules: config.rules ?? DEFAULT_CONFIG.rules,
     "third-party": config["third-party"] ?? DEFAULT_CONFIG["third-party"],
     registry: config.registry,
+    lint: config.lint,
   };
 }

--- a/packages/north/src/config/loader.ts
+++ b/packages/north/src/config/loader.ts
@@ -236,6 +236,9 @@ function mergeConfigs(
 
     // Registry: child overrides
     registry: child.registry ?? parent.registry,
+
+    // Lint: child overrides
+    lint: child.lint ?? parent.lint,
   };
 }
 

--- a/packages/north/src/config/schema.ts
+++ b/packages/north/src/config/schema.ts
@@ -175,6 +175,18 @@ export const RegistryConfigSchema = z
 export type RegistryConfig = z.infer<typeof RegistryConfigSchema>;
 
 // ============================================================================
+// Lint Configuration
+// ============================================================================
+
+export const LintConfigSchema = z
+  .object({
+    classFunctions: z.array(z.string()).min(1).optional(),
+  })
+  .optional();
+
+export type LintConfig = z.infer<typeof LintConfigSchema>;
+
+// ============================================================================
 // Main North Configuration
 // ============================================================================
 
@@ -187,6 +199,7 @@ export const NorthConfigSchema = z.object({
   rules: RulesConfigSchema.optional(),
   "third-party": ThirdPartyConfigSchema.optional(),
   registry: RegistryConfigSchema.optional(),
+  lint: LintConfigSchema,
 });
 
 export type NorthConfig = z.infer<typeof NorthConfigSchema>;

--- a/packages/north/src/index.ts
+++ b/packages/north/src/index.ts
@@ -12,6 +12,7 @@ export {
   type RulesConfig,
   type ThirdPartyConfig,
   type RegistryConfig,
+  type LintConfig,
   type RadiusDial,
   type ShadowsDial,
   type DensityDial,
@@ -100,3 +101,10 @@ export {
   type DoctorOptions,
   type DoctorResult,
 } from "./commands/doctor.ts";
+
+export {
+  check,
+  type CheckOptions,
+  type CheckResult,
+  CheckError,
+} from "./commands/check.ts";

--- a/packages/north/src/lint/context.ts
+++ b/packages/north/src/lint/context.ts
@@ -1,0 +1,15 @@
+import type { LintContext } from "./types.ts";
+
+export function getContext(filePath: string): LintContext {
+  const normalized = filePath.replace(/\\/g, "/");
+
+  if (/(^|\/)(ui|primitives)\//.test(normalized)) {
+    return "primitive";
+  }
+
+  if (/(^|\/)(layouts|templates)\//.test(normalized)) {
+    return "layout";
+  }
+
+  return "composed";
+}

--- a/packages/north/src/lint/default-rules.ts
+++ b/packages/north/src/lint/default-rules.ts
@@ -1,0 +1,55 @@
+export interface RuleTemplate {
+  filename: string;
+  content: string;
+}
+
+export const DEFAULT_RULE_TEMPLATES: RuleTemplate[] = [
+  {
+    filename: "no-raw-palette.yaml",
+    content: `id: north/no-raw-palette
+language: tsx
+severity: error
+message: "Use semantic color tokens instead of raw Tailwind palette colors"
+rule:
+  kind: string_fragment
+  regex: "(bg|text|border|ring|fill|stroke)-(red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|zinc|neutral|stone)-\\\\d+(?:\\\\/\\\\d+)?"
+note: |
+  Replace with semantic token:
+  - bg-blue-500 -> bg-primary
+  - text-gray-600 -> text-muted-foreground
+  - border-slate-200 -> border-border
+`,
+  },
+  {
+    filename: "no-arbitrary-values.yaml",
+    content: `id: north/no-arbitrary-values
+language: tsx
+severity: error
+message: "Use scale tokens or variable shorthand instead of arbitrary literal values"
+rule:
+  kind: string_fragment
+  regex: "\\\\[[^\\\\]]+\\\\]"
+note: |
+  Prohibited: p-[13px], w-[347px], rounded-[5px]
+  Allowed: p-(--control-padding), w-(--sidebar-width)
+
+  Bracket values are allowed only if they reference a token:
+  - p-[calc(var(--spacing-md)*1.5)]
+  - w-[calc(var(--sidebar-width)+var(--spacing-lg))]
+`,
+  },
+  {
+    filename: "no-arbitrary-colors.yaml",
+    content: `id: north/no-arbitrary-colors
+language: tsx
+severity: error
+message: "Use semantic color tokens instead of arbitrary color values"
+rule:
+  kind: string_fragment
+  regex: "(bg|text|border|ring|fill|stroke)-\\\\[(#|rgb|rgba|hsl|hsla|oklch|lab|lch)[^\\\\]]+\\\\]"
+note: |
+  Prohibited: bg-[#ff0000], text-[rgb(0,0,0)]
+  Use semantic tokens: bg-destructive, text-foreground
+`,
+  },
+];

--- a/packages/north/src/lint/engine.ts
+++ b/packages/north/src/lint/engine.ts
@@ -1,0 +1,336 @@
+import { readFile } from "node:fs/promises";
+import { isAbsolute, relative, resolve } from "node:path";
+import { glob } from "glob";
+import { findConfigFile, loadConfig } from "../config/loader.ts";
+import { extractClassTokens } from "./extract.ts";
+import { loadRules } from "./rules.ts";
+import type {
+  ClassToken,
+  ExtractionResult,
+  LintIssue,
+  LintReport,
+  LintStats,
+  LintSummary,
+  LoadedRule,
+  RuleSeverity,
+} from "./types.ts";
+
+// ============================================================================
+// Lint Engine
+// ============================================================================
+
+export class LintError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = "LintError";
+  }
+}
+
+const DEFAULT_IGNORES = [
+  "**/node_modules/**",
+  "**/.git/**",
+  "**/.next/**",
+  "**/.north/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/coverage/**",
+  "**/.turbo/**",
+  "**/north/**",
+];
+
+interface LintOptions {
+  cwd?: string;
+  configPath?: string;
+  files?: string[];
+  collectIssues?: boolean;
+}
+
+interface LintRun {
+  report: LintReport;
+  configPath: string;
+}
+
+function createSummary(issues: LintIssue[]): LintSummary {
+  return issues.reduce<LintSummary>(
+    (acc, issue) => {
+      if (issue.severity === "error") {
+        acc.errors += 1;
+      } else if (issue.severity === "warn") {
+        acc.warnings += 1;
+      } else {
+        acc.info += 1;
+      }
+
+      return acc;
+    },
+    { errors: 0, warnings: 0, info: 0 }
+  );
+}
+
+function adjustSeverityForContext(
+  ruleKey: string,
+  severity: RuleSeverity,
+  context: ClassToken["context"]
+): RuleSeverity {
+  if (severity === "off") {
+    return "off";
+  }
+
+  if (ruleKey === "no-arbitrary-values" && context === "layout" && severity === "error") {
+    return "warn";
+  }
+
+  return severity;
+}
+
+function splitByDelimiter(input: string, delimiter: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let bracketDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+
+    if (char === "[") {
+      bracketDepth += 1;
+    } else if (char === "]") {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+    } else if (char === "(") {
+      parenDepth += 1;
+    } else if (char === ")") {
+      parenDepth = Math.max(0, parenDepth - 1);
+    }
+
+    if (char === delimiter && bracketDepth === 0 && parenDepth === 0) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  parts.push(current);
+  return parts;
+}
+
+function getUtilitySegment(className: string): string {
+  const parts = splitByDelimiter(className, ":");
+  return parts[parts.length - 1] ?? className;
+}
+
+function isArbitraryColorUtility(className: string): boolean {
+  const utility = getUtilitySegment(className);
+  return /^(bg|text|border|ring|fill|stroke)-\[(#|rgb|rgba|hsl|hsla|oklch|lab|lch)/.test(utility);
+}
+
+function isArbitraryValueViolation(className: string): boolean {
+  const utility = getUtilitySegment(className);
+  if (!utility.includes("[")) {
+    return false;
+  }
+
+  if (!utility.includes("]")) {
+    return false;
+  }
+
+  if (utility.includes("var(--")) {
+    return false;
+  }
+
+  return true;
+}
+
+function evaluateRule(rule: LoadedRule, token: ClassToken): LintIssue | null {
+  const severity = adjustSeverityForContext(rule.key, rule.severity, token.context);
+  if (severity === "off") {
+    return null;
+  }
+
+  if (rule.key === "no-arbitrary-values") {
+    if (isArbitraryColorUtility(token.value)) {
+      return null;
+    }
+
+    if (!isArbitraryValueViolation(token.value)) {
+      return null;
+    }
+
+    return {
+      ruleId: rule.id,
+      ruleKey: rule.key,
+      severity,
+      message: rule.message,
+      filePath: token.filePath,
+      line: token.line,
+      column: token.column,
+      className: token.value,
+      note: rule.note,
+      context: token.context,
+    };
+  }
+
+  if (rule.regex?.test(token.value)) {
+    return {
+      ruleId: rule.id,
+      ruleKey: rule.key,
+      severity,
+      message: rule.message,
+      filePath: token.filePath,
+      line: token.line,
+      column: token.column,
+      className: token.value,
+      note: rule.note,
+      context: token.context,
+    };
+  }
+
+  return null;
+}
+
+function computeStats(results: ExtractionResult[], totalFiles: number): LintStats {
+  const filesWithClasses = results.filter((result) => result.tokens.length > 0).length;
+  const filesWithNonLiteral = results.filter((result) => result.nonLiteralSites.length > 0).length;
+  const extractedClassCount = results.reduce((acc, result) => acc + result.tokens.length, 0);
+  const classSites = results.reduce((acc, result) => acc + result.classSites, 0);
+  const coveragePercent =
+    totalFiles === 0 ? 100 : Math.round((filesWithClasses / totalFiles) * 100);
+
+  return {
+    totalFiles,
+    filesWithClasses,
+    filesWithNonLiteral,
+    extractedClassCount,
+    classSites,
+    coveragePercent,
+  };
+}
+
+function sortIssues(issues: LintIssue[]): LintIssue[] {
+  return [...issues].sort((a, b) => {
+    if (a.filePath !== b.filePath) {
+      return a.filePath.localeCompare(b.filePath);
+    }
+    if (a.line !== b.line) {
+      return a.line - b.line;
+    }
+    return a.column - b.column;
+  });
+}
+
+async function loadProjectConfig(cwd: string, configOverride?: string) {
+  if (configOverride) {
+    const configPath = resolve(cwd, configOverride);
+    const result = await loadConfig(configPath);
+    if (!result.success) {
+      throw new LintError(result.error.message, result.error);
+    }
+
+    return { config: result.config, configPath };
+  }
+
+  const configPath = await findConfigFile(cwd);
+  if (!configPath) {
+    throw new LintError("Config file not found. Run 'north init' to initialize.");
+  }
+
+  const result = await loadConfig(configPath);
+  if (!result.success) {
+    throw new LintError(result.error.message, result.error);
+  }
+
+  return { config: result.config, configPath };
+}
+
+async function listFiles(cwd: string, fileOverrides?: string[]): Promise<string[]> {
+  if (fileOverrides && fileOverrides.length > 0) {
+    return fileOverrides.map((file) => (isAbsolute(file) ? file : resolve(cwd, file)));
+  }
+
+  const files = await glob("**/*.{tsx,jsx}", {
+    cwd,
+    absolute: true,
+    nodir: true,
+    ignore: DEFAULT_IGNORES,
+  });
+
+  return files;
+}
+
+function buildNonLiteralIssues(sites: ExtractionResult["nonLiteralSites"]): LintIssue[] {
+  return sites.map((site) => ({
+    ruleId: "north/non-literal-classname",
+    ruleKey: "non-literal-classname",
+    severity: "warn",
+    message: "className contains non-literal values; lint coverage reduced",
+    filePath: site.filePath,
+    line: site.line,
+    column: site.column,
+    context: site.context,
+  }));
+}
+
+export async function runLint(options: LintOptions = {}): Promise<LintRun> {
+  const cwd = options.cwd ?? process.cwd();
+  const { config, configPath } = await loadProjectConfig(cwd, options.configPath);
+
+  const rulesDir = resolve(configPath, "..", "rules");
+  const rules = await loadRules(rulesDir, config);
+
+  const files = await listFiles(cwd, options.files);
+  const extractionResults: ExtractionResult[] = [];
+  const issues: LintIssue[] = [];
+
+  for (const file of files) {
+    const displayPath = relative(cwd, file) || file;
+    try {
+      const source = await readFile(file, "utf-8");
+      const extraction = extractClassTokens(source, displayPath, {
+        classFunctions: config.lint?.classFunctions,
+      });
+
+      extractionResults.push(extraction);
+
+      if (options.collectIssues !== false) {
+        for (const token of extraction.tokens) {
+          for (const rule of rules) {
+            const issue = evaluateRule(rule, token);
+            if (issue) {
+              issues.push(issue);
+            }
+          }
+        }
+
+        issues.push(...buildNonLiteralIssues(extraction.nonLiteralSites));
+      }
+    } catch (error) {
+      issues.push({
+        ruleId: "north/parse-error",
+        ruleKey: "parse-error",
+        severity: "error",
+        message: `Failed to parse file: ${error instanceof Error ? error.message : String(error)}`,
+        filePath: displayPath,
+        line: 1,
+        column: 1,
+      });
+    }
+  }
+
+  const stats = computeStats(extractionResults, files.length);
+  const sortedIssues = sortIssues(issues);
+  const summary = createSummary(sortedIssues);
+
+  return {
+    report: {
+      summary,
+      issues: sortedIssues,
+      stats,
+      rules,
+    },
+    configPath,
+  };
+}

--- a/packages/north/src/lint/extract.ts
+++ b/packages/north/src/lint/extract.ts
@@ -1,0 +1,336 @@
+import { Lang, type SgNode, parse } from "@ast-grep/napi";
+import { getContext } from "./context.ts";
+import type { ClassToken, ExtractionResult, NonLiteralSite } from "./types.ts";
+
+const DEFAULT_CLASS_FUNCTIONS = ["cn", "clsx", "cva"] as const;
+
+interface ExtractionOptions {
+  classFunctions?: string[];
+}
+
+interface LiteralAnalysis {
+  fragments: Array<{ text: string; startLine: number; startColumn: number }>;
+  nonLiteral: boolean;
+}
+
+function splitClassTokens(text: string): Array<{ value: string; startOffset: number }> {
+  const tokens: Array<{ value: string; startOffset: number }> = [];
+  let current = "";
+  let startOffset = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    if (!char) {
+      continue;
+    }
+
+    if (char === "[") {
+      bracketDepth += 1;
+    } else if (char === "]") {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+    } else if (char === "(") {
+      parenDepth += 1;
+    } else if (char === ")") {
+      parenDepth = Math.max(0, parenDepth - 1);
+    }
+
+    const isWhitespace = /\s/.test(char);
+    if (isWhitespace && bracketDepth === 0 && parenDepth === 0) {
+      if (current.length > 0) {
+        tokens.push({ value: current, startOffset });
+        current = "";
+      }
+      continue;
+    }
+
+    if (current.length === 0) {
+      startOffset = i;
+    }
+
+    current += char;
+  }
+
+  if (current.length > 0) {
+    tokens.push({ value: current, startOffset });
+  }
+
+  return tokens;
+}
+
+function offsetToLineColumn(text: string, baseLine: number, baseColumn: number, offset: number) {
+  const prefix = text.slice(0, offset);
+  const lines = prefix.split("\n");
+  if (lines.length === 1) {
+    return { line: baseLine, column: baseColumn + offset };
+  }
+
+  return {
+    line: baseLine + lines.length - 1,
+    column: (lines[lines.length - 1] ?? "").length,
+  };
+}
+
+function fragmentHasTemplateSubstitution(fragmentNode: SgNode): boolean {
+  const ancestors = fragmentNode.ancestors();
+  for (const ancestor of ancestors) {
+    if (ancestor.kind() === "template_string") {
+      const substitution = ancestor.find({ rule: { kind: "template_substitution" } });
+      return Boolean(substitution);
+    }
+  }
+
+  return false;
+}
+
+function collectLiteralFragments(
+  node: SgNode
+): Array<{ text: string; startLine: number; startColumn: number }> {
+  const fragments: Array<{ text: string; startLine: number; startColumn: number }> = [];
+  const nodes = node.findAll({ rule: { kind: "string_fragment" } });
+
+  for (const fragment of nodes) {
+    if (fragmentHasTemplateSubstitution(fragment)) {
+      continue;
+    }
+
+    const range = fragment.range();
+    fragments.push({
+      text: fragment.text(),
+      startLine: range.start.line,
+      startColumn: range.start.column,
+    });
+  }
+
+  return fragments;
+}
+
+function isLiteralExpression(node: SgNode): boolean {
+  const kind = node.kind();
+
+  if (kind === "string") {
+    return true;
+  }
+
+  if (kind === "template_string") {
+    return !node.find({ rule: { kind: "template_substitution" } });
+  }
+
+  if (kind === "parenthesized_expression") {
+    const inner = node.children().find((child) => child.isNamed());
+    return inner ? isLiteralExpression(inner) : false;
+  }
+
+  if (kind === "as_expression" || kind === "type_assertion") {
+    const inner = node.children().find((child) => child.isNamed());
+    return inner ? isLiteralExpression(inner) : false;
+  }
+
+  return false;
+}
+
+function analyzeExpression(node: SgNode, classFunctions: string[]): LiteralAnalysis {
+  const kind = node.kind();
+
+  if (kind === "call_expression") {
+    const callee = node.children().find((child) => child.kind() === "identifier");
+    const calleeName = callee?.text() ?? "";
+
+    if (!classFunctions.includes(calleeName)) {
+      return {
+        fragments: collectLiteralFragments(node),
+        nonLiteral: true,
+      };
+    }
+
+    const argumentsNode = node.children().find((child) => child.kind() === "arguments");
+    const argNodes = argumentsNode?.children().filter((child) => child.isNamed()) ?? [];
+
+    let nonLiteral = false;
+    for (const arg of argNodes) {
+      if (!isLiteralExpression(arg)) {
+        nonLiteral = true;
+        break;
+      }
+    }
+
+    return {
+      fragments: collectLiteralFragments(argumentsNode ?? node),
+      nonLiteral,
+    };
+  }
+
+  return {
+    fragments: collectLiteralFragments(node),
+    nonLiteral: !isLiteralExpression(node),
+  };
+}
+
+function analyzeClassNameAttribute(attr: SgNode, classFunctions: string[]): LiteralAnalysis {
+  const stringNode = attr.children().find((child) => child.kind() === "string");
+  if (stringNode) {
+    return {
+      fragments: collectLiteralFragments(stringNode),
+      nonLiteral: false,
+    };
+  }
+
+  const expressionNode = attr
+    .find({ rule: { kind: "jsx_expression" } })
+    ?.children()
+    .find((child) => child.isNamed());
+
+  if (expressionNode) {
+    return analyzeExpression(expressionNode, classFunctions);
+  }
+
+  return {
+    fragments: [],
+    nonLiteral: false,
+  };
+}
+
+function isInsideClassNameAttribute(node: SgNode): boolean {
+  return node
+    .ancestors()
+    .some(
+      (ancestor) =>
+        ancestor.kind() === "jsx_attribute" &&
+        ancestor.find({ rule: { kind: "property_identifier", regex: "^className$" } })
+    );
+}
+
+function analyzeCallExpression(node: SgNode, classFunctions: string[]): LiteralAnalysis | null {
+  const callee = node.children().find((child) => child.kind() === "identifier");
+  if (!callee) {
+    return null;
+  }
+
+  if (!classFunctions.includes(callee.text())) {
+    return null;
+  }
+
+  const argumentsNode = node.children().find((child) => child.kind() === "arguments");
+  const argNodes = argumentsNode?.children().filter((child) => child.isNamed()) ?? [];
+
+  let nonLiteral = false;
+  for (const arg of argNodes) {
+    if (!isLiteralExpression(arg)) {
+      nonLiteral = true;
+      break;
+    }
+  }
+
+  return {
+    fragments: collectLiteralFragments(argumentsNode ?? node),
+    nonLiteral,
+  };
+}
+
+export function extractClassTokens(
+  source: string,
+  filePath: string,
+  options: ExtractionOptions = {}
+): ExtractionResult {
+  const classFunctions = options.classFunctions ?? [...DEFAULT_CLASS_FUNCTIONS];
+  const root = parse(Lang.Tsx, source);
+  const context = getContext(filePath);
+
+  const tokens: ClassToken[] = [];
+  const nonLiteralSites: NonLiteralSite[] = [];
+  let classSites = 0;
+
+  const classNameAttrs = root.root().findAll({ rule: { kind: "jsx_attribute" } });
+
+  for (const attr of classNameAttrs) {
+    const nameNode = attr.find({ rule: { kind: "property_identifier", regex: "^className$" } });
+    if (!nameNode) {
+      continue;
+    }
+
+    classSites += 1;
+    const analysis = analyzeClassNameAttribute(attr, classFunctions);
+    const range = attr.range();
+
+    if (analysis.nonLiteral) {
+      nonLiteralSites.push({
+        filePath,
+        line: range.start.line + 1,
+        column: range.start.column + 1,
+        context,
+      });
+    }
+
+    for (const fragment of analysis.fragments) {
+      const classTokens = splitClassTokens(fragment.text);
+      for (const token of classTokens) {
+        const pos = offsetToLineColumn(
+          fragment.text,
+          fragment.startLine,
+          fragment.startColumn,
+          token.startOffset
+        );
+
+        tokens.push({
+          value: token.value,
+          filePath,
+          line: pos.line + 1,
+          column: pos.column + 1,
+          context,
+        });
+      }
+    }
+  }
+
+  const callExpressions = root.root().findAll({ rule: { kind: "call_expression" } });
+
+  for (const call of callExpressions) {
+    if (isInsideClassNameAttribute(call)) {
+      continue;
+    }
+
+    const analysis = analyzeCallExpression(call, classFunctions);
+    if (!analysis) {
+      continue;
+    }
+
+    classSites += 1;
+    const range = call.range();
+
+    if (analysis.nonLiteral) {
+      nonLiteralSites.push({
+        filePath,
+        line: range.start.line + 1,
+        column: range.start.column + 1,
+        context,
+      });
+    }
+
+    for (const fragment of analysis.fragments) {
+      const classTokens = splitClassTokens(fragment.text);
+      for (const token of classTokens) {
+        const pos = offsetToLineColumn(
+          fragment.text,
+          fragment.startLine,
+          fragment.startColumn,
+          token.startOffset
+        );
+
+        tokens.push({
+          value: token.value,
+          filePath,
+          line: pos.line + 1,
+          column: pos.column + 1,
+          context,
+        });
+      }
+    }
+  }
+
+  return {
+    tokens,
+    nonLiteralSites,
+    classSites,
+  };
+}

--- a/packages/north/src/lint/format.ts
+++ b/packages/north/src/lint/format.ts
@@ -1,0 +1,65 @@
+import chalk from "chalk";
+import type { LintIssue, LintReport } from "./types.ts";
+
+function formatLocation(issue: LintIssue): string {
+  return `${issue.filePath}:${issue.line}:${issue.column}`;
+}
+
+function formatIssueLine(issue: LintIssue): string {
+  const symbol = issue.severity === "error" ? chalk.red("✗") : chalk.yellow("⚠");
+  const ruleLabel = chalk.dim(`[${issue.ruleId}]`);
+  const location = chalk.cyan(formatLocation(issue));
+  return `${symbol} ${location} ${ruleLabel} ${issue.message}`;
+}
+
+function formatIssueDetail(issue: LintIssue): string[] {
+  const lines: string[] = [];
+
+  if (issue.className) {
+    lines.push(chalk.dim(`  class: ${issue.className}`));
+  }
+
+  if (issue.context) {
+    lines.push(chalk.dim(`  context: ${issue.context}`));
+  }
+
+  if (issue.note) {
+    const noteLines = issue.note.split("\n").map((line) => line.trim());
+    if (noteLines.length > 0) {
+      lines.push(chalk.dim("  note:"));
+      for (const noteLine of noteLines) {
+        if (noteLine.length === 0) {
+          continue;
+        }
+        lines.push(chalk.dim(`    ${noteLine}`));
+      }
+    }
+  }
+
+  return lines;
+}
+
+export function formatLintReport(report: LintReport): string {
+  const lines: string[] = [];
+  const { errors, warnings, info } = report.summary;
+
+  if (report.issues.length === 0) {
+    lines.push(chalk.bold.green("✓ No lint issues found"));
+    return lines.join("\n");
+  }
+
+  lines.push(
+    chalk.bold(
+      `Found ${report.issues.length} issues (${errors} errors, ${warnings} warnings, ${info} info)`
+    )
+  );
+  lines.push("");
+
+  for (const issue of report.issues) {
+    lines.push(formatIssueLine(issue));
+    lines.push(...formatIssueDetail(issue));
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}

--- a/packages/north/src/lint/rules.ts
+++ b/packages/north/src/lint/rules.ts
@@ -1,0 +1,131 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { glob } from "glob";
+import { parse as parseYAML } from "yaml";
+import type { NorthConfig } from "../config/schema.ts";
+import type { LoadedRule, RuleSeverity } from "./types.ts";
+
+// ============================================================================
+// Rule Loading
+// ============================================================================
+
+export class RuleLoadError extends Error {
+  constructor(
+    message: string,
+    public readonly filePath?: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = "RuleLoadError";
+  }
+}
+
+const VALID_SEVERITIES: RuleSeverity[] = ["error", "warn", "info", "off"];
+
+function normalizeRuleKey(ruleId: string): string {
+  const parts = ruleId.split("/");
+  return parts[parts.length - 1] ?? ruleId;
+}
+
+function resolveRuleLevel(config: NorthConfig, ruleKey: string): RuleSeverity | null {
+  const rulesConfig = config.rules;
+  if (!rulesConfig) {
+    return null;
+  }
+
+  const value = rulesConfig[ruleKey as keyof typeof rulesConfig];
+
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    return value as RuleSeverity;
+  }
+
+  if (typeof value === "object" && "level" in value) {
+    return value.level as RuleSeverity;
+  }
+
+  return null;
+}
+
+function toSeverity(value: unknown, fallback: RuleSeverity): RuleSeverity {
+  if (typeof value === "string" && VALID_SEVERITIES.includes(value as RuleSeverity)) {
+    return value as RuleSeverity;
+  }
+
+  return fallback;
+}
+
+export async function loadRules(rulesDir: string, config: NorthConfig): Promise<LoadedRule[]> {
+  const pattern = "**/*.yaml";
+  const files = await glob(pattern, {
+    cwd: rulesDir,
+    absolute: true,
+    nodir: true,
+  });
+
+  if (files.length === 0) {
+    throw new RuleLoadError("No rule files found", rulesDir);
+  }
+
+  const rules: LoadedRule[] = [];
+
+  for (const filePath of files) {
+    try {
+      const content = await readFile(filePath, "utf-8");
+      const data = parseYAML(content) as Record<string, unknown> | null;
+
+      if (!data || typeof data !== "object") {
+        throw new RuleLoadError("Invalid rule file format", filePath);
+      }
+
+      const id = typeof data.id === "string" ? data.id : null;
+      const message = typeof data.message === "string" ? data.message : null;
+
+      if (!id || !message) {
+        throw new RuleLoadError("Rule file missing required fields (id, message)", filePath);
+      }
+
+      const ruleKey = normalizeRuleKey(id);
+      const ruleLevel = resolveRuleLevel(config, ruleKey);
+      const baseSeverity = toSeverity(data.severity, "warn");
+      const severity = ruleLevel ?? baseSeverity;
+
+      if (severity === "off") {
+        continue;
+      }
+
+      const ruleConfig = data.rule as { regex?: unknown } | undefined;
+      const rawRegex = typeof ruleConfig?.regex === "string" ? ruleConfig.regex : undefined;
+      const regex = rawRegex ? new RegExp(rawRegex) : undefined;
+
+      rules.push({
+        id,
+        key: ruleKey,
+        message,
+        severity,
+        note: typeof data.note === "string" ? data.note : undefined,
+        regex,
+        sourcePath: resolve(filePath),
+      });
+    } catch (error) {
+      if (error instanceof RuleLoadError) {
+        throw error;
+      }
+
+      throw new RuleLoadError(
+        `Failed to load rule file: ${error instanceof Error ? error.message : String(error)}`,
+        filePath,
+        error
+      );
+    }
+  }
+
+  return rules;
+}
+
+export function getRuleKey(ruleId: string): string {
+  return normalizeRuleKey(ruleId);
+}

--- a/packages/north/src/lint/types.ts
+++ b/packages/north/src/lint/types.ts
@@ -1,0 +1,69 @@
+export type RuleSeverity = "error" | "warn" | "info" | "off";
+
+export type LintContext = "primitive" | "composed" | "layout";
+
+export interface LoadedRule {
+  id: string;
+  key: string;
+  message: string;
+  severity: RuleSeverity;
+  note?: string;
+  regex?: RegExp;
+  sourcePath: string;
+}
+
+export interface LintIssue {
+  ruleId: string;
+  ruleKey: string;
+  severity: Exclude<RuleSeverity, "off">;
+  message: string;
+  filePath: string;
+  line: number;
+  column: number;
+  className?: string;
+  note?: string;
+  context?: LintContext;
+}
+
+export interface LintSummary {
+  errors: number;
+  warnings: number;
+  info: number;
+}
+
+export interface LintStats {
+  totalFiles: number;
+  filesWithClasses: number;
+  filesWithNonLiteral: number;
+  extractedClassCount: number;
+  classSites: number;
+  coveragePercent: number;
+}
+
+export interface LintReport {
+  summary: LintSummary;
+  issues: LintIssue[];
+  stats: LintStats;
+  rules: LoadedRule[];
+}
+
+export interface ClassToken {
+  value: string;
+  filePath: string;
+  line: number;
+  column: number;
+  context: LintContext;
+}
+
+export interface NonLiteralSite {
+  filePath: string;
+  line: number;
+  column: number;
+  context: LintContext;
+}
+
+export interface ExtractionResult {
+  tokens: ClassToken[];
+  nonLiteralSites: NonLiteralSite[];
+  classSites: number;
+}


### PR DESCRIPTION
## Summary
- add lint engine with class extraction and rules evaluation
- implement `north check` with JSON/text output and staged mode
- add formatted lint reporting and rule defaults

## Regex Escaping Fix (absorbed)

**Problem**: Generated lint rule YAML files had unescaped regex backslashes, causing YAML parsing errors.

**Error**:
```
✗ Lint failed
Invalid escape sequence \d at line 7, column 178
```

**Root Cause**: TypeScript template literals used single backslashes (`\\d`) which became `\d` in YAML. YAML interprets backslashes as escape characters, causing invalid sequences like `\d`, `\[`, `\/`.

**Solution**: Doubled all backslashes in regex patterns in `default-rules.ts`:
- `\\d` → `\\\\d` (becomes `\\d` in YAML, parsed as `\d` regex)
- `\\/` → `\\\\/` (becomes `\\/` in YAML, parsed as `\/` regex)
- `\\[` → `\\\\[` (becomes `\\[` in YAML, parsed as `\[` regex)

**Results**:
- ✅ `north check` runs successfully
- ✅ Found 4,917 real lint issues in shadcn/ui repo (2,868 errors, 2,049 warnings)
- ✅ All three rule files parse correctly:
  - `no-raw-palette.yaml`
  - `no-arbitrary-values.yaml`
  - `no-arbitrary-colors.yaml`

## Testing
- bun run typecheck
- north check (verifies regex patterns parse correctly)