### PR TITLE
feat(harness): add repo registry

### DIFF
--- a/docs/stress-harness.md
+++ b/docs/stress-harness.md
@@ -27,6 +27,10 @@ harness/
   .cache/                # Clones + temp workdirs (ignored by git)
 ```
 
+## Repo registry
+
+Pinned repos live in `harness/repos.json`. Suites reference repos by name (for example, `repo: north`), and corpus entries can be marked `enabled: false` to keep heavier repos out of default runs.
+
 ## Mutation suite
 
 Mutations clone a pinned golden repo, apply a base patch + mutation patch, and run `north check --json --staged`. Results are compared against `expect.json`.

--- a/harness/corpus.yaml
+++ b/harness/corpus.yaml
@@ -4,20 +4,30 @@ defaults:
   determinismRuns: 2
 
 repos:
-  - name: north
-    url: https://github.com/outfitter-dev/north.git
-    sha: 66136affbf5faa09df93e6eeb65c497059818a64
+  - repo: north
     type: next
     paths:
       - examples/nextjs-shadcn
     index: true
 
-  - name: navigator
-    url: https://github.com/outfitter-dev/navigator.git
-    sha: 616cabd807823a19c6e054e55b697da38f4a7bfe
+  - repo: navigator
     type: vite
 
-  - name: agent-browser
-    url: https://github.com/outfitter-dev/agent-browser.git
-    sha: 6abee3764105ca823f4688bb799279e447671f55
+  - repo: agent-browser
     type: vite
+
+  - repo: shadcn-ui
+    type: next
+    enabled: false
+
+  - repo: ai-chatbot
+    type: next
+    enabled: false
+
+  - repo: shadcn-admin
+    type: vite
+    enabled: false
+
+  - repo: tanstack-start-dashboard
+    type: tanstack-start
+    enabled: false

--- a/harness/repos.json
+++ b/harness/repos.json
@@ -1,0 +1,53 @@
+{
+  "repos": [
+    {
+      "name": "north",
+      "url": "https://github.com/outfitter-dev/north.git",
+      "sha": "66136affbf5faa09df93e6eeb65c497059818a64",
+      "type": "next",
+      "tags": ["core", "next", "shadcn", "tailwind", "ci"]
+    },
+    {
+      "name": "navigator",
+      "url": "https://github.com/outfitter-dev/navigator.git",
+      "sha": "616cabd807823a19c6e054e55b697da38f4a7bfe",
+      "type": "vite",
+      "tags": ["core", "vite", "ci"]
+    },
+    {
+      "name": "agent-browser",
+      "url": "https://github.com/outfitter-dev/agent-browser.git",
+      "sha": "6abee3764105ca823f4688bb799279e447671f55",
+      "type": "vite",
+      "tags": ["core", "vite", "ci"]
+    },
+    {
+      "name": "shadcn-ui",
+      "url": "https://github.com/shadcn-ui/ui.git",
+      "sha": "d04bc84a51335d1ec4043e8dfcff874235c2a840",
+      "type": "next",
+      "tags": ["opt-in", "shadcn", "tailwind", "components", "monorepo"]
+    },
+    {
+      "name": "ai-chatbot",
+      "url": "https://github.com/vercel/ai-chatbot.git",
+      "sha": "9d5d8a3ea7968522a37ab1cc145a6c0ef8a9dd2e",
+      "type": "next",
+      "tags": ["opt-in", "shadcn", "tailwind", "app"]
+    },
+    {
+      "name": "shadcn-admin",
+      "url": "https://github.com/satnaing/shadcn-admin.git",
+      "sha": "d86ee05a0667ad5b72b8119affa2a0b11cc27fad",
+      "type": "vite",
+      "tags": ["opt-in", "shadcn", "tailwind", "app"]
+    },
+    {
+      "name": "tanstack-start-dashboard",
+      "url": "https://github.com/Kiranism/tanstack-start-dashboard.git",
+      "sha": "5a2bc5e283b6553eceb200204e96596f8195d099",
+      "type": "tanstack-start",
+      "tags": ["opt-in", "shadcn", "tailwind", "app", "tanstack"]
+    }
+  ]
+}

--- a/harness/suites/mutations/config.json
+++ b/harness/suites/mutations/config.json
@@ -1,9 +1,5 @@
 {
-  "repo": {
-    "name": "north",
-    "url": "https://github.com/outfitter-dev/north.git",
-    "sha": "66136affbf5faa09df93e6eeb65c497059818a64"
-  },
+  "repo": "north",
   "basePatch": "base.patch",
   "timeoutMs": 60000
 }

--- a/harness/suites/promote/scenarios.json
+++ b/harness/suites/promote/scenarios.json
@@ -2,22 +2,14 @@
   "scenarios": [
     {
       "id": "golden-button",
-      "repo": {
-        "name": "north",
-        "url": "https://github.com/outfitter-dev/north.git",
-        "sha": "66136affbf5faa09df93e6eeb65c497059818a64"
-      },
+      "repo": "north",
       "pattern": "rounded-md bg-primary px-4 py-2",
       "as": "button-base",
       "instances": 8
     },
     {
       "id": "corpus-card",
-      "repo": {
-        "name": "agent-browser",
-        "url": "https://github.com/outfitter-dev/agent-browser.git",
-        "sha": "6abee3764105ca823f4688bb799279e447671f55"
-      },
+      "repo": "agent-browser",
       "pattern": "rounded-lg bg-primary p-6",
       "as": "card-base",
       "instances": 7

--- a/harness/suites/ui-probes/config.json
+++ b/harness/suites/ui-probes/config.json
@@ -1,12 +1,8 @@
 {
-  "repo": {
-    "name": "north",
-    "url": "https://github.com/outfitter-dev/north.git",
-    "sha": "66136affbf5faa09df93e6eeb65c497059818a64",
-    "appDir": "examples/nextjs-shadcn",
-    "install": "bun install",
-    "devCommand": "bun run dev",
-    "port": 3000,
-    "routes": [{ "name": "home", "path": "/" }, { "name": "home-alt", "path": "/?variant=alt" }]
-  }
+  "repo": "north",
+  "appDir": "examples/nextjs-shadcn",
+  "install": "bun install",
+  "devCommand": "bun run dev",
+  "port": 3000,
+  "routes": [{ "name": "home", "path": "/" }, { "name": "home-alt", "path": "/?variant=alt" }]
 }

--- a/harness/utils/repos.ts
+++ b/harness/utils/repos.ts
@@ -1,0 +1,69 @@
+import { readJson, writeJson } from "./fs.ts";
+import { harnessPath } from "./paths.ts";
+
+export interface HarnessRepo {
+  name: string;
+  url: string;
+  sha: string;
+  type?: string;
+  tags?: string[];
+}
+
+export interface HarnessRepoRegistry {
+  repos: HarnessRepo[];
+}
+
+export type HarnessRepoRef = string | { name: string; url?: string; sha?: string };
+
+export async function readRepoRegistry(): Promise<HarnessRepoRegistry> {
+  return await readJson<HarnessRepoRegistry>(harnessPath("repos.json"));
+}
+
+export async function writeRepoRegistry(registry: HarnessRepoRegistry) {
+  await writeJson(harnessPath("repos.json"), registry);
+}
+
+export function findRepo(registry: HarnessRepoRegistry, name: string) {
+  return registry.repos.find((repo) => repo.name === name);
+}
+
+export function resolveRepo(registry: HarnessRepoRegistry, ref: HarnessRepoRef): HarnessRepo {
+  const name = typeof ref === "string" ? ref : ref.name;
+
+  // Detect org/repo format for ad-hoc GitHub repos
+  if (name.includes("/")) {
+    const [org, repoName] = name.split("/", 2);
+    if (org && repoName) {
+      return {
+        name: repoName,
+        url: `https://github.com/${org}/${repoName}.git`,
+        sha: "", // Will be resolved to HEAD in explore.ts
+      };
+    }
+  }
+
+  const repo = findRepo(registry, name);
+  if (!repo) {
+    throw new Error(`Repo '${name}' not found in harness/repos.json.`);
+  }
+
+  if (typeof ref === "string") {
+    return repo;
+  }
+
+  return {
+    ...repo,
+    url: ref.url ?? repo.url,
+    sha: ref.sha ?? repo.sha,
+  };
+}
+
+export function filterReposByTags(registry: HarnessRepoRegistry, tags: string[]) {
+  if (tags.length === 0) {
+    return registry.repos;
+  }
+  return registry.repos.filter((repo) => {
+    const repoTags = repo.tags ?? [];
+    return tags.some((tag) => repoTags.includes(tag));
+  });
+}


### PR DESCRIPTION
## Summary

Introduce a centralized repo registry for the stress harness test infrastructure.

- Add `harness/repos.json` as the single source of truth for pinned repos
- Create `harness/utils/repos.ts` with resolution utilities
- Migrate suite configs to reference repos by name instead of inline URLs
- Support `enabled: false` for opt-in corpus entries (heavier repos)
- Document registry usage in `docs/stress-harness.md`

## Registry Format

```json
{
  "repos": [
    {
      "name": "north",
      "url": "https://github.com/outfitter-dev/north.git",
      "sha": "abc123...",
      "tags": ["core"]
    }
  ]
}
```

## Test plan

- [x] Existing suites resolve repos correctly from registry
- [x] Corpus entries can be disabled via `enabled: false`
- [x] Unknown repo names throw clear errors