### PR TITLE
feat(harness): add explore helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ coverage/
 # Harness
 harness/.cache/
 harness/artifacts/
+.harness/

--- a/docs/stress-harness.md
+++ b/docs/stress-harness.md
@@ -43,6 +43,15 @@ bun run harness:bump-sha --tag opt-in
 bun run harness:bump-sha --repo my-app --ref main
 ```
 
+### Explore sessions
+
+Explore sessions set up a repo workspace and drop a `northx` wrapper that logs every command into `.harness/sessions/<session>/<repo>/`.
+
+```bash
+bun run harness:explore --repo shadcn-ui --mode shell --session baseline
+./northx check --json --config ./north/north.config.yaml
+```
+
 ## Mutation suite
 
 Mutations clone a pinned golden repo, apply a base patch + mutation patch, and run `north check --json --staged`. Results are compared against `expect.json`.

--- a/harness/explore.ts
+++ b/harness/explore.ts
@@ -1,0 +1,268 @@
+import { spawn } from "node:child_process";
+import { chmod, rm, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { hasFlag, readFlag } from "./utils/args.ts";
+import { runCommand } from "./utils/exec.ts";
+import { copyDir, ensureDir, pathExists, readJson, readText, writeJson } from "./utils/fs.ts";
+import { checkoutRef, cloneRepo, resolveRemoteSha } from "./utils/git.ts";
+import { repoPath } from "./utils/paths.ts";
+import { readRepoRegistry, resolveRepo } from "./utils/repos.ts";
+
+interface ExploreOptions {
+  repo: string;
+  ref?: string;
+  sha?: string;
+  fresh?: boolean;
+  mode: "prepare" | "shell" | "run";
+  session?: string;
+  command?: string[];
+}
+
+function printHelp() {
+  console.log(`Harness Explore
+
+Usage:
+  bun run harness:explore --repo <name> [--ref <ref> | --sha <sha>] [--fresh] [--mode <prepare|shell|run>] [--session <name>] [-- <north args>]
+
+Examples:
+  bun run harness:explore --repo shadcn-ui --mode shell
+  bun run harness:explore --repo shadcn-ui -- check --json
+  bun run harness:explore --repo shadcn-ui --ref main -- check --json
+  bun run harness:explore --repo vercel/next.js --mode shell
+
+Options:
+  --repo <name>   Repo name from harness/repos.json, or org/repo for GitHub
+  --ref <ref>     Git ref to resolve (default: pinned SHA or HEAD)
+  --sha <sha>     Explicit SHA override
+  --fresh         Re-clone the repo workspace
+  --mode <mode>   prepare (default), shell, or run
+  --session <id>  Group multiple repos in the same session
+`);
+}
+
+function parseArgs(raw: string[]): ExploreOptions {
+  const delimiterIndex = raw.indexOf("--");
+  const args = delimiterIndex === -1 ? raw : raw.slice(0, delimiterIndex);
+  const command = delimiterIndex === -1 ? undefined : raw.slice(delimiterIndex + 1);
+
+  if (hasFlag(args, "--help") || hasFlag(args, "-h")) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const repo = readFlag(args, "--repo");
+  if (!repo) {
+    throw new Error("--repo is required.");
+  }
+
+  const ref = readFlag(args, "--ref");
+  const sha = readFlag(args, "--sha");
+  const modeFlag = readFlag(args, "--mode");
+  const session = readFlag(args, "--session");
+  const shellFlag = hasFlag(args, "--shell");
+
+  if (ref && sha) {
+    throw new Error("--ref cannot be combined with --sha.");
+  }
+
+  if (shellFlag && modeFlag && modeFlag !== "shell") {
+    throw new Error("--shell cannot be combined with --mode unless --mode shell.");
+  }
+
+  const mode = (() => {
+    if (shellFlag) {
+      return "shell" as const;
+    }
+    if (modeFlag) {
+      if (modeFlag === "prepare" || modeFlag === "shell" || modeFlag === "run") {
+        return modeFlag;
+      }
+      throw new Error(`Unknown mode '${modeFlag}'. Use prepare, shell, or run.`);
+    }
+    if (command && command.length > 0) {
+      return "run" as const;
+    }
+    return "prepare" as const;
+  })();
+
+  if (mode === "run" && (!command || command.length === 0)) {
+    throw new Error("--mode run requires a command after '--'.");
+  }
+
+  return {
+    repo,
+    ref: ref ?? undefined,
+    sha: sha ?? undefined,
+    fresh: hasFlag(args, "--fresh"),
+    mode,
+    session: session ?? undefined,
+    command: command && command.length > 0 ? command : undefined,
+  };
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+async function renderNorthxScript(options: { logRoot: string; cliPath: string }) {
+  const templatePath = repoPath("harness", "templates", "northx.js");
+  const template = await readText(templatePath);
+  return template
+    .replace('"__LOG_ROOT__"', JSON.stringify(options.logRoot))
+    .replace('"__CLI_PATH__"', JSON.stringify(options.cliPath));
+}
+
+async function ensureNorthConfig(workDir: string) {
+  const configPath = resolve(workDir, "north", "north.config.yaml");
+  if (await pathExists(configPath)) {
+    return;
+  }
+
+  const fixtureDir = repoPath("harness", "fixtures", "north", "north");
+  await copyDir(fixtureDir, resolve(workDir, "north"));
+}
+
+interface SessionIndexEntry {
+  name: string;
+  sha: string;
+  updatedAt: string;
+}
+
+interface SessionIndex {
+  id: string;
+  createdAt: string;
+  repos: SessionIndexEntry[];
+}
+
+async function updateSessionIndex(
+  sessionRoot: string,
+  sessionId: string,
+  repoName: string,
+  sha: string
+) {
+  const indexPath = resolve(sessionRoot, "index.json");
+  const now = new Date().toISOString();
+  let index: SessionIndex;
+
+  if (await pathExists(indexPath)) {
+    index = (await readJson(indexPath)) as SessionIndex;
+  } else {
+    index = { id: sessionId, createdAt: now, repos: [] };
+  }
+
+  const existing = index.repos.find((entry) => entry.name === repoName);
+  if (existing) {
+    existing.sha = sha;
+    existing.updatedAt = now;
+  } else {
+    index.repos.push({ name: repoName, sha, updatedAt: now });
+  }
+
+  await writeJson(indexPath, index);
+}
+
+async function setupRepo(options: ExploreOptions, sessionId: string) {
+  const registry = await readRepoRegistry();
+  const repo = resolveRepo(registry, options.repo);
+
+  const workRoot = repoPath(".harness", "workspaces");
+  const workDir = resolve(workRoot, repo.name);
+  const sessionRoot = repoPath(".harness", "sessions", sessionId);
+  const logRoot = resolve(sessionRoot, repo.name);
+
+  await ensureDir(workRoot);
+  await ensureDir(sessionRoot);
+  await ensureDir(logRoot);
+
+  const pinnedSha = options.sha
+    ? options.sha
+    : options.ref
+      ? await resolveRemoteSha(repo.url, options.ref)
+      : repo.sha || (await resolveRemoteSha(repo.url, "HEAD"));
+
+  if (options.fresh || !(await pathExists(workDir))) {
+    await rm(workDir, { recursive: true, force: true });
+    const cloneResult = await cloneRepo(repo.url, workDir);
+    if (cloneResult.code !== 0) {
+      throw new Error("git clone failed");
+    }
+  } else {
+    await runCommand("git", ["fetch", "--all", "--tags"], { cwd: workDir });
+  }
+
+  const checkoutResult = await checkoutRef(workDir, pinnedSha);
+  if (checkoutResult.code !== 0) {
+    throw new Error("git checkout failed");
+  }
+
+  await ensureNorthConfig(workDir);
+  await updateSessionIndex(sessionRoot, sessionId, repo.name, pinnedSha);
+
+  await writeJson(resolve(logRoot, "repo.json"), {
+    name: repo.name,
+    url: repo.url,
+    sha: pinnedSha,
+    ref: options.ref ?? null,
+    updatedAt: new Date().toISOString(),
+  });
+
+  const northxPath = resolve(workDir, "northx");
+  const northCli = repoPath("packages", "north", "src", "cli", "index.ts");
+  await writeFile(northxPath, await renderNorthxScript({ logRoot, cliPath: northCli }));
+  await chmod(northxPath, 0o755);
+
+  return { workDir, logRoot, repoName: repo.name, sha: pinnedSha, sessionId };
+}
+
+async function runShell(workDir: string, logDir: string) {
+  const shell = process.env.SHELL ?? "zsh";
+  await new Promise<void>((resolvePromise, reject) => {
+    const child = spawn(shell, {
+      cwd: workDir,
+      stdio: "inherit",
+      env: { ...process.env, NORTHX_LOG_DIR: logDir },
+    });
+    child.on("exit", () => resolvePromise());
+    child.on("error", reject);
+  });
+}
+
+async function runCommandOnce(workDir: string, logDir: string, args: string[]) {
+  const exitCode = await new Promise<number | null>((resolvePromise, reject) => {
+    const child = spawn(resolve(workDir, "northx"), args, {
+      cwd: workDir,
+      stdio: "inherit",
+      env: { ...process.env, NORTHX_LOG_DIR: logDir },
+    });
+    child.on("exit", (code) => resolvePromise(code));
+    child.on("error", reject);
+  });
+  if (exitCode !== 0) {
+    process.exitCode = exitCode ?? 1;
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const sessionId = options.session ?? timestamp();
+  const { workDir, logRoot, repoName, sha } = await setupRepo(options, sessionId);
+
+  console.log(`Repo ready: ${workDir}`);
+  console.log(`Session: ${sessionId}`);
+  console.log(`Logs: ${logRoot}`);
+  console.log("Run: ./northx <command> [args]");
+
+  if (options.mode === "run" && options.command && options.command.length > 0) {
+    await runCommandOnce(workDir, logRoot, options.command);
+    return;
+  }
+
+  if (options.mode === "shell") {
+    await runShell(workDir, logRoot);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/harness/templates/northx.js
+++ b/harness/templates/northx.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import { access, appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+
+const logRoot = process.env.NORTHX_LOG_DIR || "__LOG_ROOT__";
+const cliPath = "__CLI_PATH__";
+
+async function loadRepoMeta() {
+  try {
+    const raw = await readFile(path.join(logRoot, "repo.json"), "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+async function ensureLogRoot() {
+  await mkdir(logRoot, { recursive: true });
+  const sessionMetaPath = path.join(logRoot, "session.json");
+  try {
+    await access(sessionMetaPath);
+  } catch {
+    const repoMeta = await loadRepoMeta();
+    await writeFile(
+      sessionMetaPath,
+      JSON.stringify(
+        {
+          createdAt: new Date().toISOString(),
+          repo: repoMeta,
+          cwd: process.cwd(),
+        },
+        null,
+        2
+      )
+    );
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error("northx: pass north CLI args (ex: ./northx check --json)");
+    process.exit(1);
+  }
+
+  await ensureLogRoot();
+  const runId = `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+  const stdoutPath = path.join(logRoot, `run-${runId}.stdout.txt`);
+  const stderrPath = path.join(logRoot, `run-${runId}.stderr.txt`);
+  const logPath = path.join(logRoot, "session.jsonl");
+
+  const startedAt = Date.now();
+  const child = spawn("bun", [cliPath, ...args], {
+    cwd: process.cwd(),
+    env: { ...process.env },
+    stdio: ["inherit", "pipe", "pipe"],
+  });
+
+  const stdoutStream = createWriteStream(stdoutPath);
+  const stderrStream = createWriteStream(stderrPath);
+
+  child.stdout.on("data", (chunk) => {
+    stdoutStream.write(chunk);
+    process.stdout.write(chunk);
+  });
+
+  child.stderr.on("data", (chunk) => {
+    stderrStream.write(chunk);
+    process.stderr.write(chunk);
+  });
+
+  child.on("close", async (code, signal) => {
+    stdoutStream.end();
+    stderrStream.end();
+
+    const record = {
+      timestamp: new Date().toISOString(),
+      command: args,
+      cwd: process.cwd(),
+      exitCode: code,
+      signal,
+      durationMs: Date.now() - startedAt,
+      stdout: stdoutPath,
+      stderr: stderrPath,
+    };
+
+    await appendFile(logPath, `${JSON.stringify(record)}\n`);
+    process.exit(code ?? 1);
+  });
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "format": "turbo run format",
     "harness": "bun run ./harness/run.ts",
     "harness:bump-sha": "bun run ./harness/bump-sha.ts",
-    "harness:repos": "bun run ./harness/repos.ts"
+    "harness:repos": "bun run ./harness/repos.ts",
+    "harness:explore": "bun run ./harness/explore.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
## Summary

Add an interactive explore command for testing north against real codebases.

- Prepares a persistent workspace from a registered or GitHub repo
- Installs a `northx` wrapper script that logs all commands
- Stores session logs under `.harness/sessions/<session>/<repo>/`
- Supports shell mode for interactive exploration

## Usage

```bash
# Prepare workspace and drop into shell
bun run harness:explore --repo shadcn-ui --mode shell

# Run a specific command
bun run harness:explore --repo shadcn-ui -- check --json

# Use a specific ref
bun run harness:explore --repo shadcn-ui --ref main -- check --json

# GitHub repo (not in registry)
bun run harness:explore --repo vercel/next.js --mode shell
```

## Session Logging

The `northx` wrapper captures:
- Command arguments
- Exit codes
- Stdout/stderr output
- Timestamps

Logs are stored in `.harness/sessions/` for later analysis.

## Exit Code Propagation

Child process exit codes are now propagated to the parent process, enabling proper CI integration.

## Test plan

- [x] `--mode shell` drops into interactive shell
- [x] `-- check --json` runs command and exits
- [x] Session logs are created in `.harness/`
- [x] Exit codes propagate correctly (fixed)
- [x] `--repo` without value fails gracefully (fixed)