### PR TITLE
feat(lint): add @north-deviation inline suppression

### DIFF
--- a/packages/north/src/lint/comments.ts
+++ b/packages/north/src/lint/comments.ts
@@ -1,0 +1,143 @@
+import type { Deviation } from "./types.ts";
+
+// ============================================================================
+// Comment Parsing for @north-deviation
+// ============================================================================
+
+/**
+ * Regex to match @north-deviation block comments.
+ * Format:
+ * /* @north-deviation
+ *  * rule: rule-name
+ *  * reason: explanation
+ *  * ticket: JIRA-123 (optional)
+ *  * count: 3 (optional, defaults to 1)
+ * *\/
+ */
+const DEVIATION_BLOCK_REGEX = /\/\*\s*@north-deviation\s*\n([\s\S]*?)(?:\*\/)/g;
+
+/**
+ * Regex to match single-line @north-deviation comments.
+ * Format: // @north-deviation rule=rule-name reason="explanation"
+ */
+const DEVIATION_LINE_REGEX =
+  /\/\/\s*@north-deviation\s+rule=(\S+)\s+reason="([^"]+)"(?:\s+ticket=(\S+))?(?:\s+count=(\d+))?/g;
+
+interface DeviationField {
+  rule?: string;
+  reason?: string;
+  ticket?: string;
+  count?: number;
+}
+
+function parseBlockFields(content: string): DeviationField {
+  const fields: DeviationField = {};
+
+  // Parse YAML-like fields from block comment content
+  const lines = content.split("\n");
+  for (const line of lines) {
+    // Remove leading asterisks and whitespace
+    const cleaned = line.replace(/^\s*\*?\s*/, "").trim();
+    if (!cleaned) continue;
+
+    const colonIndex = cleaned.indexOf(":");
+    if (colonIndex === -1) continue;
+
+    const key = cleaned.slice(0, colonIndex).trim().toLowerCase();
+    const value = cleaned.slice(colonIndex + 1).trim();
+
+    switch (key) {
+      case "rule":
+        fields.rule = value;
+        break;
+      case "reason":
+        fields.reason = value;
+        break;
+      case "ticket":
+        fields.ticket = value;
+        break;
+      case "count":
+        fields.count = Number.parseInt(value, 10) || 1;
+        break;
+    }
+  }
+
+  return fields;
+}
+
+function getLineNumber(source: string, index: number): number {
+  return source.slice(0, index).split("\n").length;
+}
+
+/**
+ * Parse @north-deviation comments from source code.
+ * Supports both block comments and single-line comments.
+ *
+ * A deviation on line N covers violations on lines N+1 through N+count.
+ */
+export function parseDeviations(source: string, filePath: string): Deviation[] {
+  const deviations: Deviation[] = [];
+
+  // Parse block comments using matchAll (modern pattern that avoids assignment in expression)
+  for (const match of source.matchAll(DEVIATION_BLOCK_REGEX)) {
+    const fields = parseBlockFields(match[1] ?? "");
+    if (fields.rule && fields.reason) {
+      // Calculate end line by counting newlines in the block comment
+      const startLine = getLineNumber(source, match.index ?? 0);
+      const newlinesInMatch = (match[0].match(/\n/g) || []).length;
+      const endLine = startLine + newlinesInMatch;
+      deviations.push({
+        rule: fields.rule,
+        reason: fields.reason,
+        ticket: fields.ticket,
+        count: fields.count ?? 1,
+        line: endLine,
+        filePath,
+      });
+    }
+  }
+
+  // Parse single-line comments
+  for (const match of source.matchAll(DEVIATION_LINE_REGEX)) {
+    const line = getLineNumber(source, match.index ?? 0);
+    deviations.push({
+      rule: match[1] ?? "",
+      reason: match[2] ?? "",
+      ticket: match[3],
+      count: match[4] ? Number.parseInt(match[4], 10) : 1,
+      line,
+      filePath,
+    });
+  }
+
+  return deviations;
+}
+
+/**
+ * Check if an issue is covered by a deviation.
+ * A deviation on line N covers issues on lines N+1 through N+count.
+ */
+export function isIssueCoveredByDeviation(
+  issueRule: string,
+  issueLine: number,
+  deviations: Deviation[]
+): Deviation | null {
+  for (const deviation of deviations) {
+    const startLine = deviation.line + 1;
+    const endLine = deviation.line + deviation.count;
+
+    // Normalize rule names for comparison (strip north/ prefix)
+    const normalizedIssueRule = issueRule.replace(/^north\//, "");
+    const normalizedDeviationRule = deviation.rule.replace(/^north\//, "");
+
+    if (
+      normalizedIssueRule === normalizedDeviationRule &&
+      issueLine >= startLine &&
+      issueLine <= endLine
+    ) {
+      return deviation;
+    }
+  }
+
+  return null;
+}

--- a/packages/north/src/lint/format.ts
+++ b/packages/north/src/lint/format.ts
@@ -42,17 +42,23 @@ function formatIssueDetail(issue: LintIssue): string[] {
 export function formatLintReport(report: LintReport): string {
   const lines: string[] = [];
   const { errors, warnings, info } = report.summary;
+  const deviationCount = report.deviations.length;
 
   if (report.issues.length === 0) {
-    lines.push(chalk.bold.green("✓ No lint issues found"));
+    const successMessage = chalk.bold.green("✓ No lint issues found");
+    if (deviationCount > 0) {
+      lines.push(`${successMessage} ${chalk.dim(`(${deviationCount} deviations acknowledged)`)}`);
+    } else {
+      lines.push(successMessage);
+    }
     return lines.join("\n");
   }
 
-  lines.push(
-    chalk.bold(
-      `Found ${report.issues.length} issues (${errors} errors, ${warnings} warnings, ${info} info)`
-    )
-  );
+  let summaryLine = `Found ${report.issues.length} issues (${errors} errors, ${warnings} warnings, ${info} info)`;
+  if (deviationCount > 0) {
+    summaryLine += chalk.dim(` [${deviationCount} deviations]`);
+  }
+  lines.push(chalk.bold(summaryLine));
   lines.push("");
 
   for (const issue of report.issues) {

--- a/packages/north/src/lint/types.ts
+++ b/packages/north/src/lint/types.ts
@@ -2,6 +2,19 @@ export type RuleSeverity = "error" | "warn" | "info" | "off";
 
 export type LintContext = "primitive" | "composed" | "layout";
 
+// ============================================================================
+// Deviation Types
+// ============================================================================
+
+export interface Deviation {
+  rule: string;
+  reason: string;
+  ticket?: string;
+  count: number;
+  line: number;
+  filePath: string;
+}
+
 export interface LoadedRule {
   id: string;
   key: string;
@@ -46,6 +59,7 @@ export interface LintReport {
   issues: LintIssue[];
   stats: LintStats;
   rules: LoadedRule[];
+  deviations: Deviation[];
 }
 
 export interface ClassToken {


### PR DESCRIPTION
## Summary

Add comment-based lint suppression with structured metadata for tracking.

- Support block comments with YAML-like fields (rule, reason, ticket, count)
- Support single-line format for quick suppressions
- Deviation on line N covers violations on lines N+1 through N+count
- Display deviation count in lint output

## Formats

Block comment:
```tsx
/* @north-deviation
 * rule: no-arbitrary-values
 * reason: Legacy API constraint
 * ticket: JIRA-123
 * count: 3
 */
```

Single-line:
```tsx
// @north-deviation rule=no-arbitrary-values reason="One-off override"
```

## Test plan

- [ ] Verify block comment deviations suppress matching issues
- [ ] Verify single-line deviations work
- [ ] Confirm count parameter covers correct line range
- [ ] Check deviation count appears in output

Closes #50