### PR TITLE
feat(lint): add @north-candidate pattern promotion

### DIFF
--- a/packages/north/src/lint/engine.ts
+++ b/packages/north/src/lint/engine.ts
@@ -4,11 +4,12 @@ import { glob } from "glob";
 import { minimatch } from "minimatch";
 import { findConfigFile, loadConfig } from "../config/loader.ts";
 import type { NorthConfig } from "../config/schema.ts";
-import { isIssueCoveredByDeviation, parseDeviations } from "./comments.ts";
+import { isIssueCoveredByDeviation, parseCandidates, parseDeviations } from "./comments.ts";
 import { extractClassTokens } from "./extract.ts";
 import { getIgnorePatterns } from "./ignores.ts";
 import { loadRules } from "./rules.ts";
 import type {
+  Candidate,
   ClassToken,
   Deviation,
   ExtractionResult,
@@ -297,6 +298,7 @@ export async function runLint(options: LintOptions = {}): Promise<LintRun> {
   const extractionResults: ExtractionResult[] = [];
   const rawIssues: LintIssue[] = [];
   const allDeviations: Deviation[] = [];
+  const allCandidates: Candidate[] = [];
 
   for (const file of files) {
     const displayPath = relative(cwd, file) || file;
@@ -311,6 +313,10 @@ export async function runLint(options: LintOptions = {}): Promise<LintRun> {
       // Parse deviations from this file
       const fileDeviations = parseDeviations(source, displayPath);
       allDeviations.push(...fileDeviations);
+
+      // Parse candidates from this file
+      const fileCandidates = parseCandidates(source, displayPath);
+      allCandidates.push(...fileCandidates);
 
       if (options.collectIssues !== false) {
         for (const token of extraction.tokens) {
@@ -354,6 +360,7 @@ export async function runLint(options: LintOptions = {}): Promise<LintRun> {
       stats,
       rules,
       deviations: allDeviations,
+      candidates: allCandidates,
     },
     configPath,
   };

--- a/packages/north/src/lint/format.ts
+++ b/packages/north/src/lint/format.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import type { LintIssue, LintReport } from "./types.ts";
+import type { Candidate, LintIssue, LintReport } from "./types.ts";
 
 function formatLocation(issue: LintIssue): string {
   return `${issue.filePath}:${issue.line}:${issue.column}`;
@@ -39,17 +39,53 @@ function formatIssueDetail(issue: LintIssue): string[] {
   return lines;
 }
 
+function formatCandidates(candidates: Candidate[]): string[] {
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  const lines: string[] = [];
+  lines.push(chalk.bold.blue(`Candidates for promotion (${candidates.length}):`));
+  lines.push("");
+
+  for (const candidate of candidates) {
+    const location = chalk.cyan(`${candidate.filePath}:${candidate.line}`);
+    const pattern = chalk.yellow(candidate.pattern);
+    lines.push(`  ${location} ${pattern}`);
+    if (candidate.occurrences > 0) {
+      lines.push(chalk.dim(`    occurrences: ${candidate.occurrences}`));
+    }
+    lines.push(chalk.dim(`    suggestion: ${candidate.suggestion}`));
+    lines.push("");
+  }
+
+  return lines;
+}
+
 export function formatLintReport(report: LintReport): string {
   const lines: string[] = [];
   const { errors, warnings, info } = report.summary;
   const deviationCount = report.deviations.length;
+  const candidateCount = report.candidates.length;
 
   if (report.issues.length === 0) {
     const successMessage = chalk.bold.green("✓ No lint issues found");
+    const annotations: string[] = [];
     if (deviationCount > 0) {
-      lines.push(`${successMessage} ${chalk.dim(`(${deviationCount} deviations acknowledged)`)}`);
+      annotations.push(`${deviationCount} deviations`);
+    }
+    if (candidateCount > 0) {
+      annotations.push(`${candidateCount} candidates`);
+    }
+    if (annotations.length > 0) {
+      lines.push(`${successMessage} ${chalk.dim(`(${annotations.join(", ")})`)}`);
     } else {
       lines.push(successMessage);
+    }
+    // Still show candidates even when no issues
+    if (candidateCount > 0) {
+      lines.push("");
+      lines.push(...formatCandidates(report.candidates));
     }
     return lines.join("\n");
   }
@@ -65,6 +101,11 @@ export function formatLintReport(report: LintReport): string {
     lines.push(formatIssueLine(issue));
     lines.push(...formatIssueDetail(issue));
     lines.push("");
+  }
+
+  // Add candidates section if any exist
+  if (candidateCount > 0) {
+    lines.push(...formatCandidates(report.candidates));
   }
 
   return lines.join("\n");

--- a/packages/north/src/lint/types.ts
+++ b/packages/north/src/lint/types.ts
@@ -15,6 +15,14 @@ export interface Deviation {
   filePath: string;
 }
 
+export interface Candidate {
+  pattern: string;
+  occurrences: number;
+  suggestion: string;
+  filePath: string;
+  line: number;
+}
+
 export interface LoadedRule {
   id: string;
   key: string;
@@ -60,6 +68,7 @@ export interface LintReport {
   stats: LintStats;
   rules: LoadedRule[];
   deviations: Deviation[];
+  candidates: Candidate[];
 }
 
 export interface ClassToken {


### PR DESCRIPTION
## Summary

Add `@north-candidate` comments to mark patterns that should be promoted to reusable utilities.

- Parse candidate comments with pattern, occurrences, and suggestion fields
- Display candidates in lint output
- Provides visibility into technical debt and refactoring opportunities

## Format

```tsx
/* @north-candidate
 * pattern: card-spacing
 * occurrences: 12
 * suggestion: Extract to a spacing utility or cva variant
 */
```

## Test plan

- [ ] Verify candidate comments are parsed correctly
- [ ] Confirm candidates display in lint output
- [ ] Check all fields (pattern, occurrences, suggestion) are captured

Closes #51