### PR TITLE
feat(lint): add deviation tracking and aggregation

### DIFF
--- a/packages/north/src/lint/tracking.ts
+++ b/packages/north/src/lint/tracking.ts
@@ -1,0 +1,86 @@
+import type { Candidate, Deviation, DeviationGroup } from "./types.ts";
+
+// ============================================================================
+// Deviation Tracking and Aggregation
+// ============================================================================
+
+/**
+ * Result of deviation aggregation analysis.
+ */
+export interface DeviationAnalysis {
+  groups: DeviationGroup[];
+  suggestedCandidates: Candidate[];
+}
+
+/** Threshold for suggesting promotion to @north-candidate */
+const PROMOTION_THRESHOLD = 3;
+
+/**
+ * Aggregate deviations by rule and reason to identify repeated patterns.
+ * If the same rule+reason combination appears 3+ times, suggest promoting
+ * to a @north-candidate pattern.
+ */
+export function aggregateDeviations(deviations: Deviation[]): DeviationAnalysis {
+  // Group deviations by rule+reason
+  const groupMap = new Map<string, DeviationGroup>();
+
+  for (const deviation of deviations) {
+    const key = `${deviation.rule}::${deviation.reason}`;
+    const existing = groupMap.get(key);
+
+    if (existing) {
+      existing.count += deviation.count;
+      existing.locations.push({
+        filePath: deviation.filePath,
+        line: deviation.line,
+      });
+    } else {
+      groupMap.set(key, {
+        rule: deviation.rule,
+        reason: deviation.reason,
+        count: deviation.count,
+        locations: [{ filePath: deviation.filePath, line: deviation.line }],
+      });
+    }
+  }
+
+  const groups = Array.from(groupMap.values()).sort((a, b) => b.count - a.count);
+
+  // Suggest candidates for groups that meet the threshold
+  const suggestedCandidates: Candidate[] = groups
+    .filter((group) => group.count >= PROMOTION_THRESHOLD)
+    .map((group) => ({
+      pattern: `${group.rule}-deviation`,
+      occurrences: group.count,
+      suggestion: `Consider extracting "${group.reason}" pattern to a reusable utility or updating the rule`,
+      filePath: group.locations[0]?.filePath ?? "",
+      line: group.locations[0]?.line ?? 0,
+    }));
+
+  return {
+    groups,
+    suggestedCandidates,
+  };
+}
+
+/**
+ * Format deviation groups as a histogram for display.
+ */
+export function formatDeviationHistogram(groups: DeviationGroup[]): string[] {
+  if (groups.length === 0) {
+    return [];
+  }
+
+  const lines: string[] = [];
+  const maxCount = Math.max(...groups.map((g) => g.count));
+  const barWidth = 20;
+
+  for (const group of groups) {
+    const barLength = Math.ceil((group.count / maxCount) * barWidth);
+    const bar = "#".repeat(barLength).padEnd(barWidth);
+    lines.push(`  ${group.count.toString().padStart(3)} ${bar} ${group.rule}`);
+    lines.push(`      ${group.reason}`);
+  }
+
+  return lines;
+}

--- a/packages/north/src/lint/types.ts
+++ b/packages/north/src/lint/types.ts
@@ -23,6 +23,13 @@ export interface Candidate {
   line: number;
 }
 
+export interface DeviationGroup {
+  rule: string;
+  reason: string;
+  count: number;
+  locations: Array<{ filePath: string; line: number }>;
+}
+
 export interface LoadedRule {
   id: string;
   key: string;
@@ -69,6 +76,7 @@ export interface LintReport {
   rules: LoadedRule[];
   deviations: Deviation[];
   candidates: Candidate[];
+  deviationGroups: DeviationGroup[];
 }
 
 export interface ClassToken {


### PR DESCRIPTION
## Summary

Aggregate deviations by rule and reason to identify patterns worth promoting.

- Group deviations by rule + reason combination
- Generate histogram visualization in output
- Auto-suggest candidates when same rule+reason appears 3+ times
- Merge suggested candidates with manually declared ones

## Output Example

```
Deviation breakdown (3 patterns):
   7 #################### no-arbitrary-values
       Legacy API constraint
   4 ###########          no-raw-palette
       Brand color not tokenized
   3 ########             no-arbitrary-values
       Third-party component
```

## Test plan

- [ ] Verify deviations are grouped correctly
- [ ] Confirm histogram renders with proper bar scaling
- [ ] Check auto-suggested candidates appear at threshold (3+)

Closes #54