### PR TITLE
feat(lint): add numeric-spacing-in-component rule

### DIFF
--- a/packages/north/src/lint/default-rules.ts
+++ b/packages/north/src/lint/default-rules.ts
@@ -52,4 +52,22 @@ note: |
   Use semantic tokens: bg-destructive, text-foreground
 `,
   },
+  {
+    filename: "numeric-spacing-in-component.yaml",
+    content: `id: north/numeric-spacing-in-component
+language: tsx
+severity: warn
+message: "Use semantic spacing tokens instead of numeric values in components"
+rule:
+  kind: string_fragment
+  regex: "(p|px|py|pt|pr|pb|pl|m|mx|my|mt|mr|mb|ml|gap|gap-x|gap-y|space-x|space-y|inset|top|right|bottom|left)-\\\\d+(\\\\.\\\\d+)?$"
+note: |
+  In component files, prefer semantic spacing tokens:
+  - p-4 -> p-(--spacing-md)
+  - gap-2 -> gap-(--spacing-sm)
+
+  This rule is OFF in layout context where numeric spacing is acceptable.
+  This rule is ERROR in primitive context where strict token usage is required.
+`,
+  },
 ];

--- a/packages/north/src/lint/engine.ts
+++ b/packages/north/src/lint/engine.ts
@@ -13,7 +13,6 @@ import type {
   Candidate,
   ClassToken,
   Deviation,
-  DeviationGroup,
   ExtractionResult,
   LintIssue,
   LintReport,
@@ -77,6 +76,17 @@ function adjustSeverityForContext(
 
   if (ruleKey === "no-arbitrary-values" && context === "layout" && severity === "error") {
     return "warn";
+  }
+
+  // numeric-spacing-in-component: off in layout, error in primitive, warn (default) in composed
+  if (ruleKey === "numeric-spacing-in-component") {
+    if (context === "layout") {
+      return "off";
+    }
+    if (context === "primitive") {
+      return "error";
+    }
+    // composed context keeps default (warn)
   }
 
   return severity;

--- a/packages/north/src/lint/format.ts
+++ b/packages/north/src/lint/format.ts
@@ -77,7 +77,9 @@ function formatDeviationHistogram(groups: DeviationGroup[]): string[] {
   for (const group of groups.slice(0, 10)) {
     const barLength = Math.ceil((group.count / maxCount) * barWidth);
     const bar = chalk.magenta("#".repeat(barLength).padEnd(barWidth));
-    lines.push(`  ${chalk.yellow(group.count.toString().padStart(3))} ${bar} ${chalk.cyan(group.rule)}`);
+    lines.push(
+      `  ${chalk.yellow(group.count.toString().padStart(3))} ${bar} ${chalk.cyan(group.rule)}`
+    );
     lines.push(chalk.dim(`      ${group.reason}`));
   }
 


### PR DESCRIPTION
## Summary

Add rule that warns about numeric spacing classes (p-4, gap-2, m-8) in component context.

- Context-aware severity adjustment:
  - `layout` context: off (numeric spacing is expected)
  - `composed` context: warn (prefer semantic tokens)
  - `primitive` context: error (must use semantic tokens)
- Encourages semantic spacing tokens like `p-control`, `gap-card`

## Test plan

- [ ] Verify rule fires on numeric spacing in composed components
- [ ] Confirm rule is off in layout files
- [ ] Check rule is error severity in primitive components

Closes #57