### PR TITLE
feat(lint): add component-complexity rule

### DIFF
--- a/packages/north/src/lint/default-rules.ts
+++ b/packages/north/src/lint/default-rules.ts
@@ -89,4 +89,27 @@ note: |
   Tailwind utility classes to ensure consistency and dark mode support.
 `,
   },
+  {
+    filename: "component-complexity.yaml",
+    content: `id: north/component-complexity
+language: tsx
+severity: warn
+message: "Component has too many utility classes; consider extracting to composable utilities"
+rule:
+  kind: jsx_attribute
+  has:
+    kind: property_identifier
+    regex: "^className$"
+note: |
+  Class count thresholds by context:
+  - primitive: 10 classes (strict, should be simple)
+  - composed: 15 classes (moderate complexity allowed)
+  - layout: 20 classes (more flexibility for layout concerns)
+
+  When a className attribute exceeds these thresholds, consider:
+  - Extracting repeated patterns to utility functions
+  - Using component variants with cva()
+  - Creating semantic wrapper components
+`,
+  },
 ];


### PR DESCRIPTION
## Summary

Add rule that evaluates className complexity at the site level.

- Context-specific thresholds:
  - `primitive`: 10 classes max
  - `composed`: 15 classes max  
  - `layout`: 20 classes max
- Suggests extracting repeated patterns to utilities or cva() variants
- Evaluates each className site independently

## Test plan

- [ ] Verify warning fires when class count exceeds threshold
- [ ] Confirm different thresholds apply per context
- [ ] Check message includes actual count and threshold

Closes #56