### PR TITLE
feat(cli): enrich context with token intents

### DIFF
--- a/packages/north/src/cli/index.ts
+++ b/packages/north/src/cli/index.ts
@@ -98,6 +98,7 @@ program
   .option("-c, --config <path>", "Path to config file")
   .option("--compact", "Output minimal context")
   .option("--json", "Output JSON")
+  .option("--include-values", "Include raw token values (default: roles only)")
   .option("-q, --quiet", "Suppress output")
   .action(async (options) => {
     const result = await context({
@@ -105,6 +106,7 @@ program
       config: options.config,
       compact: options.compact,
       json: options.json,
+      includeValues: options.includeValues,
       quiet: options.quiet,
     });
 

--- a/packages/north/src/tokens/parse-tokens.test.ts
+++ b/packages/north/src/tokens/parse-tokens.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import { categorizeToken, getTokenIntent, parseTokensFromCss } from "./parse-tokens.ts";
+
+const SAMPLE_GENERATED_CSS = `
+@theme {
+  --color-background: oklch(1 0 0);
+  --color-foreground: oklch(0.145 0 0);
+  --color-primary: oklch(0.145 0 0);
+  --color-primary-foreground: oklch(0.97 0 0);
+  --color-surface-base: var(--color-background);
+  --color-surface-raised: var(--color-card);
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --shadow-subtle: 0 1px 2px 0 oklch(0 0 0 / 0.05);
+  --shadow-default: 0 1px 3px 0 oklch(0 0 0 / 0.1);
+  --text-body: 1rem;
+  --text-heading: 1.5rem;
+  --text-ui: 0.875rem;
+  --leading-body: 1.5;
+  --tracking-body: 0;
+  --weight-body: 400;
+  --layer-base: 0;
+  --layer-modal: 400;
+  --control-height-md: 2.5rem;
+  --breakpoint-md: 768px;
+  --container-prose: 65ch;
+}
+`;
+
+describe("parseTokensFromCss", () => {
+  test("extracts token names from @theme block", () => {
+    const result = parseTokensFromCss(SAMPLE_GENERATED_CSS);
+
+    expect(result.tokens).toContainEqual(expect.objectContaining({ name: "--color-background" }));
+    expect(result.tokens).toContainEqual(expect.objectContaining({ name: "--spacing-md" }));
+    expect(result.tokens).toContainEqual(expect.objectContaining({ name: "--radius-lg" }));
+  });
+
+  test("includes values when includeValues is true", () => {
+    const result = parseTokensFromCss(SAMPLE_GENERATED_CSS, { includeValues: true });
+
+    const spacingMd = result.tokens.find((t) => t.name === "--spacing-md");
+    expect(spacingMd?.value).toBe("1rem");
+  });
+
+  test("excludes values when includeValues is false (default)", () => {
+    const result = parseTokensFromCss(SAMPLE_GENERATED_CSS);
+
+    const spacingMd = result.tokens.find((t) => t.name === "--spacing-md");
+    expect(spacingMd?.value).toBeUndefined();
+  });
+
+  test("categorizes tokens correctly", () => {
+    const result = parseTokensFromCss(SAMPLE_GENERATED_CSS);
+
+    expect(result.categories.colors).toContainEqual(
+      expect.objectContaining({ name: "--color-background" })
+    );
+    expect(result.categories.surfaces).toContainEqual(
+      expect.objectContaining({ name: "--color-surface-base" })
+    );
+    expect(result.categories.spacing).toContainEqual(
+      expect.objectContaining({ name: "--spacing-md" })
+    );
+    expect(result.categories.typography).toContainEqual(
+      expect.objectContaining({ name: "--text-body" })
+    );
+    expect(result.categories.radii).toContainEqual(
+      expect.objectContaining({ name: "--radius-md" })
+    );
+    expect(result.categories.shadows).toContainEqual(
+      expect.objectContaining({ name: "--shadow-default" })
+    );
+    expect(result.categories.layers).toContainEqual(
+      expect.objectContaining({ name: "--layer-modal" })
+    );
+    expect(result.categories.controls).toContainEqual(
+      expect.objectContaining({ name: "--control-height-md" })
+    );
+    expect(result.categories.breakpoints).toContainEqual(
+      expect.objectContaining({ name: "--breakpoint-md" })
+    );
+    expect(result.categories.containers).toContainEqual(
+      expect.objectContaining({ name: "--container-prose" })
+    );
+  });
+
+  test("returns empty result for empty CSS", () => {
+    const result = parseTokensFromCss("");
+
+    expect(result.tokens).toEqual([]);
+    expect(result.categories.colors).toEqual([]);
+  });
+
+  test("handles CSS without @theme block", () => {
+    const css = ":root { --foo: bar; }";
+    const result = parseTokensFromCss(css);
+
+    expect(result.tokens).toEqual([]);
+  });
+});
+
+describe("categorizeToken", () => {
+  test("categorizes color tokens", () => {
+    expect(categorizeToken("--color-primary")).toBe("colors");
+    expect(categorizeToken("--color-background")).toBe("colors");
+  });
+
+  test("categorizes surface tokens separately from colors", () => {
+    expect(categorizeToken("--color-surface-base")).toBe("surfaces");
+    expect(categorizeToken("--color-surface-raised")).toBe("surfaces");
+  });
+
+  test("categorizes spacing tokens", () => {
+    expect(categorizeToken("--spacing-md")).toBe("spacing");
+    expect(categorizeToken("--spacing-xl")).toBe("spacing");
+  });
+
+  test("categorizes typography tokens", () => {
+    expect(categorizeToken("--text-body")).toBe("typography");
+    expect(categorizeToken("--leading-body")).toBe("typography");
+    expect(categorizeToken("--tracking-body")).toBe("typography");
+    expect(categorizeToken("--weight-body")).toBe("typography");
+  });
+
+  test("categorizes radius tokens", () => {
+    expect(categorizeToken("--radius-md")).toBe("radii");
+  });
+
+  test("categorizes shadow tokens", () => {
+    expect(categorizeToken("--shadow-default")).toBe("shadows");
+  });
+
+  test("categorizes layer tokens", () => {
+    expect(categorizeToken("--layer-modal")).toBe("layers");
+  });
+
+  test("categorizes control tokens", () => {
+    expect(categorizeToken("--control-height-md")).toBe("controls");
+  });
+
+  test("categorizes breakpoint tokens", () => {
+    expect(categorizeToken("--breakpoint-md")).toBe("breakpoints");
+  });
+
+  test("categorizes container tokens", () => {
+    expect(categorizeToken("--container-prose")).toBe("containers");
+  });
+
+  test("returns 'other' for unknown tokens", () => {
+    expect(categorizeToken("--unknown-token")).toBe("other");
+  });
+});
+
+describe("getTokenIntent", () => {
+  test("returns semantic intent for common color tokens", () => {
+    expect(getTokenIntent("--color-background")).toBe("Primary app background");
+    expect(getTokenIntent("--color-foreground")).toBe("Primary text color");
+    expect(getTokenIntent("--color-primary")).toBe("Primary interactive elements and CTAs");
+    expect(getTokenIntent("--color-primary-foreground")).toBe(
+      "Text on primary-colored backgrounds"
+    );
+    expect(getTokenIntent("--color-destructive")).toBe("Destructive/danger actions");
+    expect(getTokenIntent("--color-muted")).toBe("Subtle backgrounds, disabled states");
+    expect(getTokenIntent("--color-muted-foreground")).toBe("Secondary/muted text");
+  });
+
+  test("returns semantic intent for surface tokens", () => {
+    expect(getTokenIntent("--color-surface-base")).toBe("Base layer background");
+    expect(getTokenIntent("--color-surface-raised")).toBe("Elevated elements (cards, modals)");
+    expect(getTokenIntent("--color-surface-inset")).toBe("Recessed/input backgrounds");
+    expect(getTokenIntent("--color-surface-overlay")).toBe("Overlay/popover backgrounds");
+  });
+
+  test("returns semantic intent for spacing tokens", () => {
+    expect(getTokenIntent("--spacing-xs")).toBe("Minimal spacing (icons, tight groups)");
+    expect(getTokenIntent("--spacing-sm")).toBe("Small spacing (within components)");
+    expect(getTokenIntent("--spacing-md")).toBe("Medium spacing (between related elements)");
+    expect(getTokenIntent("--spacing-lg")).toBe("Large spacing (section padding)");
+    expect(getTokenIntent("--spacing-xl")).toBe("Extra-large spacing (major sections)");
+  });
+
+  test("returns semantic intent for typography tokens", () => {
+    expect(getTokenIntent("--text-display")).toBe("Hero text, large marketing headlines");
+    expect(getTokenIntent("--text-heading")).toBe("Section headings");
+    expect(getTokenIntent("--text-body")).toBe("Body text, paragraphs");
+    expect(getTokenIntent("--text-ui")).toBe("UI elements (buttons, labels)");
+    expect(getTokenIntent("--text-caption")).toBe("Small helper text, captions");
+  });
+
+  test("returns semantic intent for radius tokens", () => {
+    expect(getTokenIntent("--radius-sm")).toBe("Subtle rounding (inputs, small cards)");
+    expect(getTokenIntent("--radius-md")).toBe("Standard rounding (buttons, cards)");
+    expect(getTokenIntent("--radius-full")).toBe("Fully rounded (avatars, pills)");
+  });
+
+  test("returns semantic intent for shadow tokens", () => {
+    expect(getTokenIntent("--shadow-subtle")).toBe("Minimal elevation");
+    expect(getTokenIntent("--shadow-default")).toBe("Standard elevation");
+    expect(getTokenIntent("--shadow-elevated")).toBe("High elevation (modals, popovers)");
+  });
+
+  test("returns semantic intent for layer tokens", () => {
+    expect(getTokenIntent("--layer-base")).toBe("Default stacking level");
+    expect(getTokenIntent("--layer-modal")).toBe("Modal dialogs");
+    expect(getTokenIntent("--layer-tooltip")).toBe("Tooltips (highest level)");
+  });
+
+  test("returns undefined for tokens without defined intent", () => {
+    expect(getTokenIntent("--unknown-custom-token")).toBeUndefined();
+  });
+});

--- a/packages/north/src/tokens/parse-tokens.ts
+++ b/packages/north/src/tokens/parse-tokens.ts
@@ -1,0 +1,258 @@
+/**
+ * Token Parser
+ *
+ * Parses CSS custom properties from North's generated.css
+ * and categorizes them with semantic intents.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface Token {
+  name: string;
+  value?: string;
+  intent?: string;
+}
+
+export interface TokenCategories {
+  surfaces: Token[];
+  colors: Token[];
+  spacing: Token[];
+  typography: Token[];
+  radii: Token[];
+  shadows: Token[];
+  layers: Token[];
+  controls: Token[];
+  breakpoints: Token[];
+  containers: Token[];
+  other: Token[];
+}
+
+export interface ParsedTokens {
+  tokens: Token[];
+  categories: TokenCategories;
+}
+
+export interface ParseOptions {
+  includeValues?: boolean;
+}
+
+// ============================================================================
+// Category Detection
+// ============================================================================
+
+type TokenCategory = keyof TokenCategories;
+
+const CATEGORY_PATTERNS: Array<{ pattern: RegExp; category: TokenCategory }> = [
+  // Surface tokens come first (more specific than general colors)
+  { pattern: /^--color-surface-/, category: "surfaces" },
+  { pattern: /^--color-/, category: "colors" },
+  { pattern: /^--spacing-/, category: "spacing" },
+  { pattern: /^--text-/, category: "typography" },
+  { pattern: /^--leading-/, category: "typography" },
+  { pattern: /^--tracking-/, category: "typography" },
+  { pattern: /^--weight-/, category: "typography" },
+  { pattern: /^--radius-/, category: "radii" },
+  { pattern: /^--shadow-/, category: "shadows" },
+  { pattern: /^--layer-/, category: "layers" },
+  { pattern: /^--control-/, category: "controls" },
+  { pattern: /^--breakpoint-/, category: "breakpoints" },
+  { pattern: /^--container-/, category: "containers" },
+];
+
+export function categorizeToken(name: string): TokenCategory {
+  for (const { pattern, category } of CATEGORY_PATTERNS) {
+    if (pattern.test(name)) {
+      return category;
+    }
+  }
+  return "other";
+}
+
+// ============================================================================
+// Intent Mapping
+// ============================================================================
+
+const TOKEN_INTENTS: Record<string, string> = {
+  // Colors - semantic meanings
+  "--color-background": "Primary app background",
+  "--color-foreground": "Primary text color",
+  "--color-card": "Card/panel background",
+  "--color-card-foreground": "Text on cards",
+  "--color-popover": "Popover/dropdown background",
+  "--color-popover-foreground": "Text on popovers",
+  "--color-primary": "Primary interactive elements and CTAs",
+  "--color-primary-foreground": "Text on primary-colored backgrounds",
+  "--color-secondary": "Secondary interactive elements",
+  "--color-secondary-foreground": "Text on secondary backgrounds",
+  "--color-muted": "Subtle backgrounds, disabled states",
+  "--color-muted-foreground": "Secondary/muted text",
+  "--color-accent": "Accent highlights, hover states",
+  "--color-accent-foreground": "Text on accent backgrounds",
+  "--color-destructive": "Destructive/danger actions",
+  "--color-destructive-foreground": "Text on destructive backgrounds",
+  "--color-border": "Default border color",
+  "--color-input": "Input field borders/backgrounds",
+  "--color-ring": "Focus ring color",
+
+  // Surfaces - elevation hierarchy
+  "--color-surface-base": "Base layer background",
+  "--color-surface-raised": "Elevated elements (cards, modals)",
+  "--color-surface-inset": "Recessed/input backgrounds",
+  "--color-surface-overlay": "Overlay/popover backgrounds",
+
+  // Spacing - usage guidance
+  "--spacing-xs": "Minimal spacing (icons, tight groups)",
+  "--spacing-sm": "Small spacing (within components)",
+  "--spacing-md": "Medium spacing (between related elements)",
+  "--spacing-lg": "Large spacing (section padding)",
+  "--spacing-xl": "Extra-large spacing (major sections)",
+  "--spacing-2xl": "Maximum spacing (page-level separation)",
+
+  // Typography - text hierarchy
+  "--text-display": "Hero text, large marketing headlines",
+  "--text-title": "Page titles",
+  "--text-heading": "Section headings",
+  "--text-subheading": "Subsection headings",
+  "--text-body": "Body text, paragraphs",
+  "--text-ui": "UI elements (buttons, labels)",
+  "--text-caption": "Small helper text, captions",
+  "--text-micro": "Tiny text (badges, counts)",
+
+  // Line height
+  "--leading-display": "Display text line height",
+  "--leading-title": "Title line height",
+  "--leading-heading": "Heading line height",
+  "--leading-body": "Body text line height",
+  "--leading-ui": "UI element line height",
+
+  // Letter spacing
+  "--tracking-display": "Display text letter spacing",
+  "--tracking-title": "Title letter spacing",
+  "--tracking-heading": "Heading letter spacing",
+  "--tracking-body": "Body text letter spacing",
+  "--tracking-ui": "UI element letter spacing",
+  "--tracking-caps": "All-caps text letter spacing",
+
+  // Font weights
+  "--weight-display": "Display text weight",
+  "--weight-title": "Title weight",
+  "--weight-heading": "Heading weight",
+  "--weight-body": "Body text weight",
+  "--weight-ui": "UI element weight",
+  "--weight-strong": "Emphasis/strong weight",
+
+  // Radii - corner treatments
+  "--radius-xs": "Minimal rounding (tiny elements)",
+  "--radius-sm": "Subtle rounding (inputs, small cards)",
+  "--radius-md": "Standard rounding (buttons, cards)",
+  "--radius-lg": "Larger rounding (dialogs, panels)",
+  "--radius-xl": "Extra-large rounding (feature cards)",
+  "--radius-full": "Fully rounded (avatars, pills)",
+
+  // Shadows - elevation
+  "--shadow-none": "No shadow",
+  "--shadow-subtle": "Minimal elevation",
+  "--shadow-default": "Standard elevation",
+  "--shadow-pronounced": "Medium elevation",
+  "--shadow-elevated": "High elevation (modals, popovers)",
+
+  // Layers - z-index stacking
+  "--layer-base": "Default stacking level",
+  "--layer-raised": "Slightly elevated (cards)",
+  "--layer-dropdown": "Dropdowns, menus",
+  "--layer-sticky": "Sticky headers/footers",
+  "--layer-overlay": "Overlay backgrounds",
+  "--layer-modal": "Modal dialogs",
+  "--layer-popover": "Popovers, floating UI",
+  "--layer-toast": "Toast notifications",
+  "--layer-tooltip": "Tooltips (highest level)",
+
+  // Controls - interactive element sizing
+  "--control-height-sm": "Small control height (compact buttons)",
+  "--control-height-md": "Standard control height",
+  "--control-height-lg": "Large control height",
+  "--control-padding-x": "Horizontal control padding",
+  "--control-padding-y": "Vertical control padding",
+  "--control-gap": "Gap between control elements",
+
+  // Breakpoints - responsive design
+  "--breakpoint-sm": "Small screens (mobile landscape)",
+  "--breakpoint-md": "Medium screens (tablets)",
+  "--breakpoint-lg": "Large screens (desktop)",
+  "--breakpoint-xl": "Extra-large screens (wide desktop)",
+  "--breakpoint-2xl": "Ultra-wide screens",
+
+  // Containers - max-widths
+  "--container-prose": "Readable text width (65ch)",
+  "--container-content": "Content area width",
+  "--container-wide": "Wide content width",
+};
+
+export function getTokenIntent(name: string): string | undefined {
+  return TOKEN_INTENTS[name];
+}
+
+// ============================================================================
+// CSS Parsing
+// ============================================================================
+
+const THEME_BLOCK_REGEX = /@theme\s*\{([^}]+)\}/;
+const CSS_VAR_REGEX = /(--[\w-]+):\s*([^;]+);/g;
+
+function createEmptyCategories(): TokenCategories {
+  return {
+    surfaces: [],
+    colors: [],
+    spacing: [],
+    typography: [],
+    radii: [],
+    shadows: [],
+    layers: [],
+    controls: [],
+    breakpoints: [],
+    containers: [],
+    other: [],
+  };
+}
+
+export function parseTokensFromCss(css: string, options: ParseOptions = {}): ParsedTokens {
+  const { includeValues = false } = options;
+
+  if (!css.trim()) {
+    return { tokens: [], categories: createEmptyCategories() };
+  }
+
+  const themeMatch = css.match(THEME_BLOCK_REGEX);
+  const themeContent = themeMatch?.[1];
+  if (!themeContent) {
+    return { tokens: [], categories: createEmptyCategories() };
+  }
+
+  const tokens: Token[] = [];
+  const categories: TokenCategories = createEmptyCategories();
+
+  const matches = themeContent.matchAll(CSS_VAR_REGEX);
+  for (const match of matches) {
+    const name = match[1];
+    const rawValue = match[2];
+    if (!name || !rawValue) continue;
+
+    const value = rawValue.trim();
+    const intent = getTokenIntent(name);
+
+    const token: Token = {
+      name,
+      ...(includeValues && { value }),
+      ...(intent && { intent }),
+    };
+
+    tokens.push(token);
+
+    const category = categorizeToken(name);
+    categories[category].push(token);
+  }
+
+  return { tokens, categories };
+}


### PR DESCRIPTION
- Add token parser module to extract tokens from generated.css
- Parse @theme block for CSS custom properties
- Categorize tokens: surfaces, colors, spacing, typography, radii,
  shadows, layers, controls, breakpoints, containers
- Add semantic intent mapping for ~60 common token names
- Add --include-values flag (default: roles only, not values)
- Integrate token output in context command (JSON and console)

Closes #80

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>