### PR TITLE
feat(cli): add --typography flag to north find

### DIFF
--- a/packages/north/src/cli/index.ts
+++ b/packages/north/src/cli/index.ts
@@ -148,6 +148,7 @@ program
   .option("-c, --config <path>", "Path to config file")
   .option("--colors", "Color usage report")
   .option("--spacing", "Spacing usage report")
+  .option("--typography", "Typography usage report")
   .option("--patterns", "Repeated class patterns")
   .option("--tokens", "Token usage report")
   .option("--cascade <selector>", "Cascade debugger for selector or token")
@@ -164,6 +165,7 @@ program
       quiet: options.quiet,
       colors: options.colors,
       spacing: options.spacing,
+      typography: options.typography,
       patterns: options.patterns,
       tokens: options.tokens,
       cascade: options.cascade,

--- a/packages/north/src/commands/find.test.ts
+++ b/packages/north/src/commands/find.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+import { TYPOGRAPHY_PREFIXES, buildTypographyUsage, parseTypographyUtility } from "./find.ts";
+
+describe("parseTypographyUtility", () => {
+  test("parses text size utilities", () => {
+    expect(parseTypographyUtility("text-xs")).toEqual({ utility: "text", value: "xs" });
+    expect(parseTypographyUtility("text-sm")).toEqual({ utility: "text", value: "sm" });
+    expect(parseTypographyUtility("text-base")).toEqual({ utility: "text", value: "base" });
+    expect(parseTypographyUtility("text-lg")).toEqual({ utility: "text", value: "lg" });
+    expect(parseTypographyUtility("text-xl")).toEqual({ utility: "text", value: "xl" });
+    expect(parseTypographyUtility("text-2xl")).toEqual({ utility: "text", value: "2xl" });
+    expect(parseTypographyUtility("text-3xl")).toEqual({ utility: "text", value: "3xl" });
+  });
+
+  test("parses font weight utilities", () => {
+    expect(parseTypographyUtility("font-thin")).toEqual({ utility: "font", value: "thin" });
+    expect(parseTypographyUtility("font-light")).toEqual({ utility: "font", value: "light" });
+    expect(parseTypographyUtility("font-normal")).toEqual({ utility: "font", value: "normal" });
+    expect(parseTypographyUtility("font-medium")).toEqual({ utility: "font", value: "medium" });
+    expect(parseTypographyUtility("font-semibold")).toEqual({ utility: "font", value: "semibold" });
+    expect(parseTypographyUtility("font-bold")).toEqual({ utility: "font", value: "bold" });
+  });
+
+  test("parses leading (line-height) utilities", () => {
+    expect(parseTypographyUtility("leading-none")).toEqual({ utility: "leading", value: "none" });
+    expect(parseTypographyUtility("leading-tight")).toEqual({ utility: "leading", value: "tight" });
+    expect(parseTypographyUtility("leading-normal")).toEqual({
+      utility: "leading",
+      value: "normal",
+    });
+    expect(parseTypographyUtility("leading-relaxed")).toEqual({
+      utility: "leading",
+      value: "relaxed",
+    });
+    expect(parseTypographyUtility("leading-loose")).toEqual({ utility: "leading", value: "loose" });
+  });
+
+  test("parses tracking (letter-spacing) utilities", () => {
+    expect(parseTypographyUtility("tracking-tighter")).toEqual({
+      utility: "tracking",
+      value: "tighter",
+    });
+    expect(parseTypographyUtility("tracking-tight")).toEqual({
+      utility: "tracking",
+      value: "tight",
+    });
+    expect(parseTypographyUtility("tracking-normal")).toEqual({
+      utility: "tracking",
+      value: "normal",
+    });
+    expect(parseTypographyUtility("tracking-wide")).toEqual({ utility: "tracking", value: "wide" });
+    expect(parseTypographyUtility("tracking-wider")).toEqual({
+      utility: "tracking",
+      value: "wider",
+    });
+    expect(parseTypographyUtility("tracking-widest")).toEqual({
+      utility: "tracking",
+      value: "widest",
+    });
+  });
+
+  test("handles responsive prefixes", () => {
+    expect(parseTypographyUtility("md:text-lg")).toEqual({ utility: "text", value: "lg" });
+    expect(parseTypographyUtility("lg:font-bold")).toEqual({ utility: "font", value: "bold" });
+    expect(parseTypographyUtility("sm:leading-tight")).toEqual({
+      utility: "leading",
+      value: "tight",
+    });
+  });
+
+  test("handles state prefixes", () => {
+    expect(parseTypographyUtility("hover:text-xl")).toEqual({ utility: "text", value: "xl" });
+    expect(parseTypographyUtility("focus:font-medium")).toEqual({
+      utility: "font",
+      value: "medium",
+    });
+  });
+
+  test("handles arbitrary values", () => {
+    expect(parseTypographyUtility("text-[14px]")).toEqual({ utility: "text", value: "[14px]" });
+    expect(parseTypographyUtility("leading-[1.5]")).toEqual({ utility: "leading", value: "[1.5]" });
+    expect(parseTypographyUtility("tracking-[0.05em]")).toEqual({
+      utility: "tracking",
+      value: "[0.05em]",
+    });
+  });
+
+  test("handles token shorthand syntax", () => {
+    expect(parseTypographyUtility("text-(--text-body)")).toEqual({
+      utility: "text",
+      value: "(--text-body)",
+    });
+    expect(parseTypographyUtility("font-(--font-weight-heading)")).toEqual({
+      utility: "font",
+      value: "(--font-weight-heading)",
+    });
+  });
+
+  test("returns null for non-typography utilities", () => {
+    expect(parseTypographyUtility("bg-blue-500")).toBeNull();
+    expect(parseTypographyUtility("p-4")).toBeNull();
+    expect(parseTypographyUtility("flex")).toBeNull();
+    expect(parseTypographyUtility("text-blue-500")).toBeNull(); // color, not typography
+  });
+});
+
+describe("TYPOGRAPHY_PREFIXES", () => {
+  test("includes all typography prefixes", () => {
+    expect(TYPOGRAPHY_PREFIXES).toContain("text");
+    expect(TYPOGRAPHY_PREFIXES).toContain("font");
+    expect(TYPOGRAPHY_PREFIXES).toContain("leading");
+    expect(TYPOGRAPHY_PREFIXES).toContain("tracking");
+  });
+});
+
+describe("buildTypographyUsage", () => {
+  test("aggregates typography values", () => {
+    const classStats = [
+      { className: "text-sm", resolvedToken: null, count: 5 },
+      { className: "text-base", resolvedToken: null, count: 3 },
+      { className: "text-sm", resolvedToken: null, count: 2 },
+      { className: "font-medium", resolvedToken: null, count: 4 },
+    ];
+
+    const result = buildTypographyUsage(classStats);
+
+    expect(result.values).toContainEqual({ value: "sm", count: 7 });
+    expect(result.values).toContainEqual({ value: "base", count: 3 });
+    expect(result.values).toContainEqual({ value: "medium", count: 4 });
+  });
+
+  test("aggregates by utility type", () => {
+    const classStats = [
+      { className: "text-sm", resolvedToken: null, count: 5 },
+      { className: "text-lg", resolvedToken: null, count: 3 },
+      { className: "font-bold", resolvedToken: null, count: 4 },
+      { className: "leading-tight", resolvedToken: null, count: 2 },
+    ];
+
+    const result = buildTypographyUsage(classStats);
+
+    expect(result.utilities).toContainEqual({ utility: "text", count: 8 });
+    expect(result.utilities).toContainEqual({ utility: "font", count: 4 });
+    expect(result.utilities).toContainEqual({ utility: "leading", count: 2 });
+  });
+
+  test("categorizes tokenized vs scale vs arbitrary", () => {
+    const classStats = [
+      { className: "text-sm", resolvedToken: null, count: 3 }, // scale
+      { className: "text-(--text-body)", resolvedToken: null, count: 2 }, // tokenized
+      { className: "text-[14px]", resolvedToken: null, count: 1 }, // arbitrary
+    ];
+
+    const result = buildTypographyUsage(classStats);
+
+    expect(result.categories.scale).toBe(3);
+    expect(result.categories.tokenized).toBe(2);
+    expect(result.categories.arbitrary).toBe(1);
+  });
+
+  test("sorts values by count descending", () => {
+    const classStats = [
+      { className: "text-sm", resolvedToken: null, count: 1 },
+      { className: "text-lg", resolvedToken: null, count: 10 },
+      { className: "text-base", resolvedToken: null, count: 5 },
+    ];
+
+    const result = buildTypographyUsage(classStats);
+
+    expect(result.values[0]).toEqual({ value: "lg", count: 10 });
+    expect(result.values[1]).toEqual({ value: "base", count: 5 });
+    expect(result.values[2]).toEqual({ value: "sm", count: 1 });
+  });
+});

--- a/packages/north/src/commands/promote.ts
+++ b/packages/north/src/commands/promote.ts
@@ -5,6 +5,7 @@ import chalk from "chalk";
 import { writeFileAtomic } from "../generation/file-writer.ts";
 import { type IndexDatabase, openIndexDatabase } from "../index/db.ts";
 import { checkIndexFresh, getIndexStatus } from "../index/queries.ts";
+import { getUtilitySegment } from "../lib/utility-classification.ts";
 
 // ============================================================================
 // Error Types
@@ -139,46 +140,6 @@ function splitPattern(pattern: string): string[] {
   }
 
   return tokens.filter(Boolean);
-}
-
-function splitByDelimiter(input: string, delimiter: string): string[] {
-  const parts: string[] = [];
-  let current = "";
-  let bracketDepth = 0;
-  let parenDepth = 0;
-
-  for (let i = 0; i < input.length; i += 1) {
-    const char = input[i];
-    if (!char) {
-      continue;
-    }
-
-    if (char === "[") {
-      bracketDepth += 1;
-    } else if (char === "]") {
-      bracketDepth = Math.max(0, bracketDepth - 1);
-    } else if (char === "(") {
-      parenDepth += 1;
-    } else if (char === ")") {
-      parenDepth = Math.max(0, parenDepth - 1);
-    }
-
-    if (char === delimiter && bracketDepth === 0 && parenDepth === 0) {
-      parts.push(current);
-      current = "";
-      continue;
-    }
-
-    current += char;
-  }
-
-  parts.push(current);
-  return parts;
-}
-
-function getUtilitySegment(className: string): string {
-  const parts = splitByDelimiter(className, ":");
-  return parts[parts.length - 1] ?? className;
 }
 
 function normalizeClasses(classes: string[]): string[] {

--- a/packages/north/src/lib/utility-classification.test.ts
+++ b/packages/north/src/lib/utility-classification.test.ts
@@ -1,0 +1,516 @@
+import { describe, expect, test } from "bun:test";
+import {
+  COLOR_PREFIXES,
+  FONT_FAMILY_VALUES,
+  SPACING_PREFIXES,
+  categorizePattern,
+  classifyUtility,
+  extractVarColorToken,
+  getUtilitySegment,
+  isArbitraryColorUtility,
+  isArbitraryValueViolation,
+  isColorLiteralValue,
+  isColorUtility,
+  isSpacingUtility,
+  isTypographyTextValue,
+  isTypographyUtility,
+  parseColorUtility,
+  parseSpacingUtility,
+  parseTypographyUtility,
+  resolveClassToToken,
+  resolveClassToTokenValidated,
+  splitByDelimiter,
+} from "./utility-classification.ts";
+
+// ============================================================================
+// Core Parsing Functions
+// ============================================================================
+
+describe("splitByDelimiter", () => {
+  test("splits simple strings", () => {
+    expect(splitByDelimiter("a:b:c", ":")).toEqual(["a", "b", "c"]);
+  });
+
+  test("respects bracket depth", () => {
+    expect(splitByDelimiter("text-[calc(1:2)]", ":")).toEqual(["text-[calc(1:2)]"]);
+  });
+
+  test("respects parenthesis depth inside", () => {
+    // Colon INSIDE parentheses should NOT split
+    expect(splitByDelimiter("func(a:b)", ":")).toEqual(["func(a:b)"]);
+  });
+
+  test("splits at colon before parentheses", () => {
+    // Colon BEFORE parentheses (at depth 0) SHOULD split
+    expect(splitByDelimiter("hover:(a:b)", ":")).toEqual(["hover", "(a:b)"]);
+  });
+
+  test("handles empty input", () => {
+    expect(splitByDelimiter("", ":")).toEqual([""]);
+  });
+
+  test("handles no delimiter", () => {
+    expect(splitByDelimiter("text-lg", ":")).toEqual(["text-lg"]);
+  });
+});
+
+describe("getUtilitySegment", () => {
+  test("extracts utility from simple class", () => {
+    expect(getUtilitySegment("text-blue-500")).toBe("text-blue-500");
+  });
+
+  test("extracts utility from prefixed class", () => {
+    expect(getUtilitySegment("hover:text-blue-500")).toBe("text-blue-500");
+  });
+
+  test("extracts utility from multiple prefixes", () => {
+    expect(getUtilitySegment("hover:md:text-blue-500")).toBe("text-blue-500");
+  });
+
+  test("preserves arbitrary values", () => {
+    expect(getUtilitySegment("hover:text-[calc(100%:2)]")).toBe("text-[calc(100%:2)]");
+  });
+});
+
+// ============================================================================
+// Color Utilities - PR #92 Fix: text-[#fff] must be classified as color
+// ============================================================================
+
+describe("isColorLiteralValue", () => {
+  test("recognizes raw color keywords", () => {
+    expect(isColorLiteralValue("transparent")).toBe(true);
+    expect(isColorLiteralValue("current")).toBe(true);
+    expect(isColorLiteralValue("black")).toBe(true);
+    expect(isColorLiteralValue("white")).toBe(true);
+  });
+
+  test("recognizes hex colors in brackets", () => {
+    expect(isColorLiteralValue("[#fff]")).toBe(true);
+    expect(isColorLiteralValue("[#ffffff]")).toBe(true);
+    expect(isColorLiteralValue("[#FF5733]")).toBe(true);
+  });
+
+  test("recognizes color functions in brackets", () => {
+    expect(isColorLiteralValue("[rgb(255,0,0)]")).toBe(true);
+    expect(isColorLiteralValue("[rgba(255,0,0,0.5)]")).toBe(true);
+    expect(isColorLiteralValue("[hsl(120,100%,50%)]")).toBe(true);
+    expect(isColorLiteralValue("[oklch(0.7_0.15_200)]")).toBe(true);
+  });
+
+  test("recognizes palette values", () => {
+    expect(isColorLiteralValue("blue-500")).toBe(true);
+    expect(isColorLiteralValue("gray-100")).toBe(true);
+    expect(isColorLiteralValue("red-50")).toBe(true);
+  });
+
+  test("rejects non-color arbitrary values", () => {
+    expect(isColorLiteralValue("[14px]")).toBe(false);
+    expect(isColorLiteralValue("[1rem]")).toBe(false);
+    expect(isColorLiteralValue("[calc(100%-20px)]")).toBe(false);
+  });
+
+  test("recognizes var(--color) references", () => {
+    expect(isColorLiteralValue("[var(--color-primary)]")).toBe(true);
+  });
+});
+
+describe("parseColorUtility", () => {
+  test("parses bg-* utilities", () => {
+    expect(parseColorUtility("bg-blue-500")).toEqual({ prefix: "bg", value: "blue-500" });
+    expect(parseColorUtility("bg-primary")).toEqual({ prefix: "bg", value: "primary" });
+  });
+
+  test("parses text-* color utilities", () => {
+    expect(parseColorUtility("text-blue-500")).toEqual({ prefix: "text", value: "blue-500" });
+    expect(parseColorUtility("text-primary")).toEqual({ prefix: "text", value: "primary" });
+  });
+
+  test("parses arbitrary color values (PR #92 fix)", () => {
+    expect(parseColorUtility("text-[#fff]")).toEqual({ prefix: "text", value: "[#fff]" });
+    expect(parseColorUtility("bg-[rgb(255,0,0)]")).toEqual({
+      prefix: "bg",
+      value: "[rgb(255,0,0)]",
+    });
+  });
+
+  test("rejects typography text-* classes", () => {
+    expect(parseColorUtility("text-lg")).toBeNull();
+    expect(parseColorUtility("text-sm")).toBeNull();
+    expect(parseColorUtility("text-base")).toBeNull();
+  });
+
+  test("parses outline-* utilities (was missing in some files)", () => {
+    expect(parseColorUtility("outline-blue-500")).toEqual({ prefix: "outline", value: "blue-500" });
+  });
+
+  test("handles prefixed classes", () => {
+    expect(parseColorUtility("hover:bg-blue-500")).toEqual({ prefix: "bg", value: "blue-500" });
+  });
+});
+
+describe("extractVarColorToken", () => {
+  test("extracts token from var() reference", () => {
+    expect(extractVarColorToken("[var(--color-primary)]")).toBe("--color-primary");
+    expect(extractVarColorToken("var(--color-secondary)")).toBe("--color-secondary");
+  });
+
+  test("returns null for non-var values", () => {
+    expect(extractVarColorToken("blue-500")).toBeNull();
+    expect(extractVarColorToken("[#fff]")).toBeNull();
+  });
+});
+
+// ============================================================================
+// Typography Utilities - PR #92 Fix: must not classify text-[#fff] as typography
+// ============================================================================
+
+describe("isTypographyTextValue", () => {
+  test("accepts scale values", () => {
+    expect(isTypographyTextValue("xs")).toBe(true);
+    expect(isTypographyTextValue("sm")).toBe(true);
+    expect(isTypographyTextValue("lg")).toBe(true);
+    expect(isTypographyTextValue("2xl")).toBe(true);
+  });
+
+  test("accepts numeric values", () => {
+    expect(isTypographyTextValue("14")).toBe(true);
+    expect(isTypographyTextValue("1.5")).toBe(true);
+  });
+
+  test("accepts token references", () => {
+    expect(isTypographyTextValue("(--text-size-lg)")).toBe(true);
+  });
+
+  test("accepts arbitrary size values", () => {
+    expect(isTypographyTextValue("[14px]")).toBe(true);
+    expect(isTypographyTextValue("[1rem]")).toBe(true);
+    expect(isTypographyTextValue("[clamp(1rem,2vw,2rem)]")).toBe(true);
+  });
+
+  test("rejects color literals (PR #92 critical fix)", () => {
+    expect(isTypographyTextValue("[#fff]")).toBe(false);
+    expect(isTypographyTextValue("[#ffffff]")).toBe(false);
+    expect(isTypographyTextValue("[rgb(255,0,0)]")).toBe(false);
+    expect(isTypographyTextValue("[rgba(0,0,0,0.5)]")).toBe(false);
+    expect(isTypographyTextValue("[hsl(120,100%,50%)]")).toBe(false);
+    expect(isTypographyTextValue("[oklch(0.7_0.15_200)]")).toBe(false);
+  });
+});
+
+describe("parseTypographyUtility", () => {
+  test("parses text-* size utilities", () => {
+    expect(parseTypographyUtility("text-lg")).toEqual({ prefix: "text", value: "lg" });
+    expect(parseTypographyUtility("text-sm")).toEqual({ prefix: "text", value: "sm" });
+    expect(parseTypographyUtility("text-2xl")).toEqual({ prefix: "text", value: "2xl" });
+  });
+
+  test("rejects text-* color utilities (PR #92 fix)", () => {
+    expect(parseTypographyUtility("text-[#fff]")).toBeNull();
+    expect(parseTypographyUtility("text-blue-500")).toBeNull();
+    expect(parseTypographyUtility("text-primary")).toBeNull();
+  });
+
+  test("parses font-* weight utilities", () => {
+    expect(parseTypographyUtility("font-bold")).toEqual({ prefix: "font", value: "bold" });
+    expect(parseTypographyUtility("font-semibold")).toEqual({ prefix: "font", value: "semibold" });
+  });
+
+  test("parses font-* family utilities (PR #92 fix - was missing)", () => {
+    expect(parseTypographyUtility("font-sans")).toEqual({ prefix: "font", value: "sans" });
+    expect(parseTypographyUtility("font-serif")).toEqual({ prefix: "font", value: "serif" });
+    expect(parseTypographyUtility("font-mono")).toEqual({ prefix: "font", value: "mono" });
+  });
+
+  test("parses leading-* utilities", () => {
+    expect(parseTypographyUtility("leading-tight")).toEqual({ prefix: "leading", value: "tight" });
+    expect(parseTypographyUtility("leading-relaxed")).toEqual({
+      prefix: "leading",
+      value: "relaxed",
+    });
+    expect(parseTypographyUtility("leading-6")).toEqual({ prefix: "leading", value: "6" });
+  });
+
+  test("parses tracking-* utilities", () => {
+    expect(parseTypographyUtility("tracking-tight")).toEqual({
+      prefix: "tracking",
+      value: "tight",
+    });
+    expect(parseTypographyUtility("tracking-wider")).toEqual({
+      prefix: "tracking",
+      value: "wider",
+    });
+  });
+
+  test("handles prefixed classes", () => {
+    expect(parseTypographyUtility("hover:text-lg")).toEqual({ prefix: "text", value: "lg" });
+    expect(parseTypographyUtility("md:font-bold")).toEqual({ prefix: "font", value: "bold" });
+  });
+});
+
+// ============================================================================
+// Spacing Utilities
+// ============================================================================
+
+describe("parseSpacingUtility", () => {
+  test("parses padding utilities", () => {
+    expect(parseSpacingUtility("p-4")).toEqual({ prefix: "p", value: "4" });
+    expect(parseSpacingUtility("px-2")).toEqual({ prefix: "px", value: "2" });
+    expect(parseSpacingUtility("py-6")).toEqual({ prefix: "py", value: "6" });
+  });
+
+  test("parses margin utilities", () => {
+    expect(parseSpacingUtility("m-4")).toEqual({ prefix: "m", value: "4" });
+    expect(parseSpacingUtility("mx-auto")).toEqual({ prefix: "mx", value: "auto" });
+    expect(parseSpacingUtility("mt-2")).toEqual({ prefix: "mt", value: "2" });
+  });
+
+  test("parses gap utilities", () => {
+    expect(parseSpacingUtility("gap-4")).toEqual({ prefix: "gap", value: "4" });
+    expect(parseSpacingUtility("gap-x-2")).toEqual({ prefix: "gap-x", value: "2" });
+    expect(parseSpacingUtility("gap-y-6")).toEqual({ prefix: "gap-y", value: "6" });
+  });
+
+  test("parses space utilities", () => {
+    expect(parseSpacingUtility("space-x-4")).toEqual({ prefix: "space-x", value: "4" });
+    expect(parseSpacingUtility("space-y-2")).toEqual({ prefix: "space-y", value: "2" });
+  });
+
+  test("parses dimension utilities (from suggest.ts)", () => {
+    expect(parseSpacingUtility("w-full")).toEqual({ prefix: "w", value: "full" });
+    expect(parseSpacingUtility("h-screen")).toEqual({ prefix: "h", value: "screen" });
+    expect(parseSpacingUtility("min-w-0")).toEqual({ prefix: "min-w", value: "0" });
+    expect(parseSpacingUtility("max-h-64")).toEqual({ prefix: "max-h", value: "64" });
+  });
+
+  test("parses arbitrary spacing values", () => {
+    expect(parseSpacingUtility("p-[20px]")).toEqual({ prefix: "p", value: "[20px]" });
+    expect(parseSpacingUtility("m-[calc(100%-20px)]")).toEqual({
+      prefix: "m",
+      value: "[calc(100%-20px)]",
+    });
+  });
+
+  test("returns null for non-spacing utilities", () => {
+    expect(parseSpacingUtility("text-lg")).toBeNull();
+    expect(parseSpacingUtility("bg-blue-500")).toBeNull();
+  });
+});
+
+describe("isSpacingUtility", () => {
+  test("identifies spacing utilities", () => {
+    expect(isSpacingUtility("p-4")).toBe(true);
+    expect(isSpacingUtility("m-2")).toBe(true);
+    expect(isSpacingUtility("gap-4")).toBe(true);
+    expect(isSpacingUtility("w-full")).toBe(true);
+  });
+
+  test("rejects non-spacing utilities", () => {
+    expect(isSpacingUtility("text-lg")).toBe(false);
+    expect(isSpacingUtility("bg-blue-500")).toBe(false);
+  });
+});
+
+// ============================================================================
+// Token Resolution
+// ============================================================================
+
+describe("resolveClassToToken", () => {
+  test("resolves shorthand token syntax", () => {
+    expect(resolveClassToToken("bg-(--color-primary)")).toBe("--color-primary");
+    expect(resolveClassToToken("p-(--spacing-md)")).toBe("--spacing-md");
+  });
+
+  test("resolves semantic color names", () => {
+    expect(resolveClassToToken("bg-primary")).toBe("--color-primary");
+    expect(resolveClassToToken("text-foreground")).toBe("--color-foreground");
+  });
+
+  test("does not resolve palette colors", () => {
+    expect(resolveClassToToken("bg-blue-500")).toBeNull();
+    expect(resolveClassToToken("text-gray-100")).toBeNull();
+  });
+
+  test("handles opacity modifiers", () => {
+    expect(resolveClassToToken("bg-primary/50")).toBe("--color-primary");
+  });
+
+  test("returns null for non-token classes", () => {
+    expect(resolveClassToToken("p-4")).toBeNull();
+    expect(resolveClassToToken("text-lg")).toBeNull();
+  });
+});
+
+describe("resolveClassToTokenValidated", () => {
+  const tokens = new Set(["--color-primary", "--color-secondary", "--spacing-md"]);
+
+  test("resolves only existing tokens", () => {
+    expect(resolveClassToTokenValidated("bg-primary", tokens)).toBe("--color-primary");
+    expect(resolveClassToTokenValidated("bg-tertiary", tokens)).toBeNull();
+  });
+
+  test("always resolves shorthand syntax", () => {
+    expect(resolveClassToTokenValidated("bg-(--color-custom)", tokens)).toBe("--color-custom");
+  });
+});
+
+// ============================================================================
+// High-Level Classification
+// ============================================================================
+
+describe("classifyUtility", () => {
+  test("classifies color utilities", () => {
+    const result = classifyUtility("bg-blue-500");
+    expect(result.category).toBe("color");
+    expect(result.parsed).toEqual({ prefix: "bg", value: "blue-500" });
+  });
+
+  test("classifies text-[#fff] as color (PR #92 fix)", () => {
+    const result = classifyUtility("text-[#fff]");
+    expect(result.category).toBe("color");
+    expect(result.parsed).toEqual({ prefix: "text", value: "[#fff]" });
+  });
+
+  test("classifies spacing utilities", () => {
+    const result = classifyUtility("p-4");
+    expect(result.category).toBe("spacing");
+    expect(result.parsed).toEqual({ prefix: "p", value: "4" });
+  });
+
+  test("classifies typography utilities", () => {
+    const result = classifyUtility("text-lg");
+    expect(result.category).toBe("typography");
+    expect(result.parsed).toEqual({ prefix: "text", value: "lg" });
+  });
+
+  test("classifies font-sans as typography (PR #92 fix)", () => {
+    const result = classifyUtility("font-sans");
+    expect(result.category).toBe("typography");
+    expect(result.parsed).toEqual({ prefix: "font", value: "sans" });
+  });
+
+  test("classifies unknown utilities", () => {
+    const result = classifyUtility("flex");
+    expect(result.category).toBe("other");
+    expect(result.parsed).toBeNull();
+  });
+
+  test("detects arbitrary values", () => {
+    expect(classifyUtility("p-[20px]").isArbitrary).toBe(true);
+    expect(classifyUtility("p-4").isArbitrary).toBe(false);
+  });
+
+  test("detects tokenized values", () => {
+    expect(classifyUtility("p-(--spacing-md)").isTokenized).toBe(true);
+    expect(classifyUtility("p-4").isTokenized).toBe(false);
+  });
+});
+
+describe("categorizePattern", () => {
+  test("categorizes pure color patterns", () => {
+    expect(categorizePattern(["bg-blue-500", "text-white"])).toBe("color");
+  });
+
+  test("categorizes pure spacing patterns", () => {
+    expect(categorizePattern(["p-4", "m-2", "gap-4"])).toBe("spacing");
+  });
+
+  test("categorizes pure typography patterns", () => {
+    expect(categorizePattern(["text-lg", "font-bold", "leading-tight"])).toBe("typography");
+  });
+
+  test("categorizes mixed patterns", () => {
+    expect(categorizePattern(["bg-blue-500", "p-4", "text-lg"])).toBe("mixed");
+  });
+
+  test("handles empty patterns", () => {
+    expect(categorizePattern([])).toBe("mixed");
+  });
+});
+
+// ============================================================================
+// Arbitrary Value Detection
+// ============================================================================
+
+describe("isArbitraryColorUtility", () => {
+  test("detects arbitrary hex colors", () => {
+    expect(isArbitraryColorUtility("bg-[#fff]")).toBe(true);
+    expect(isArbitraryColorUtility("text-[#ffffff]")).toBe(true);
+  });
+
+  test("detects arbitrary color functions", () => {
+    expect(isArbitraryColorUtility("bg-[rgb(255,0,0)]")).toBe(true);
+    expect(isArbitraryColorUtility("bg-[rgba(0,0,0,0.5)]")).toBe(true);
+    expect(isArbitraryColorUtility("bg-[hsl(120,100%,50%)]")).toBe(true);
+  });
+
+  test("rejects non-color arbitrary values", () => {
+    expect(isArbitraryColorUtility("p-[20px]")).toBe(false);
+    expect(isArbitraryColorUtility("bg-blue-500")).toBe(false);
+  });
+});
+
+describe("isArbitraryValueViolation", () => {
+  test("detects arbitrary value violations", () => {
+    expect(isArbitraryValueViolation("p-[20px]")).toBe(true);
+    expect(isArbitraryValueViolation("text-[14px]")).toBe(true);
+  });
+
+  test("excludes CSS variable usage", () => {
+    expect(isArbitraryValueViolation("p-[var(--spacing)]")).toBe(false);
+  });
+
+  test("excludes non-arbitrary values", () => {
+    expect(isArbitraryValueViolation("p-4")).toBe(false);
+    expect(isArbitraryValueViolation("text-lg")).toBe(false);
+  });
+});
+
+// ============================================================================
+// Constants Verification
+// ============================================================================
+
+describe("constants", () => {
+  test("SPACING_PREFIXES includes dimension utilities", () => {
+    expect(SPACING_PREFIXES).toContain("w");
+    expect(SPACING_PREFIXES).toContain("h");
+    expect(SPACING_PREFIXES).toContain("min-w");
+    expect(SPACING_PREFIXES).toContain("max-h");
+  });
+
+  test("COLOR_PREFIXES includes outline", () => {
+    expect(COLOR_PREFIXES).toContain("outline");
+  });
+
+  test("FONT_FAMILY_VALUES includes all families", () => {
+    expect(FONT_FAMILY_VALUES.has("sans")).toBe(true);
+    expect(FONT_FAMILY_VALUES.has("serif")).toBe(true);
+    expect(FONT_FAMILY_VALUES.has("mono")).toBe(true);
+  });
+});
+
+// ============================================================================
+// Integration Tests - Boolean Checks
+// ============================================================================
+
+describe("boolean utility checks", () => {
+  test("isTypographyUtility", () => {
+    expect(isTypographyUtility("text-lg")).toBe(true);
+    expect(isTypographyUtility("font-bold")).toBe(true);
+    expect(isTypographyUtility("font-sans")).toBe(true);
+    expect(isTypographyUtility("leading-tight")).toBe(true);
+    expect(isTypographyUtility("tracking-wide")).toBe(true);
+    expect(isTypographyUtility("text-[#fff]")).toBe(false); // Color, not typography
+    expect(isTypographyUtility("text-blue-500")).toBe(false); // Color, not typography
+    expect(isTypographyUtility("p-4")).toBe(false);
+  });
+
+  test("isColorUtility", () => {
+    expect(isColorUtility("bg-blue-500")).toBe(true);
+    expect(isColorUtility("text-primary")).toBe(true);
+    expect(isColorUtility("text-[#fff]")).toBe(true);
+    expect(isColorUtility("border-gray-200")).toBe(true);
+    expect(isColorUtility("outline-red-500")).toBe(true);
+    expect(isColorUtility("text-lg")).toBe(false); // Typography, not color
+    expect(isColorUtility("p-4")).toBe(false);
+  });
+});

--- a/packages/north/src/lib/utility-classification.ts
+++ b/packages/north/src/lib/utility-classification.ts
@@ -1,0 +1,656 @@
+/**
+ * Centralized Utility Classification Module
+ *
+ * This module consolidates all Tailwind CSS utility parsing and classification
+ * logic into a single source of truth. Previously this logic was duplicated
+ * across 6+ files with subtle inconsistencies.
+ *
+ * @see packages/north/.scratch/foundational-refactor-plan.md
+ */
+
+// ============================================================================
+// Constants - Spacing Utilities
+// ============================================================================
+
+/**
+ * All spacing-related utility prefixes.
+ * Includes padding, margin, gap, space, and dimension utilities.
+ *
+ * IMPORTANT: Longer prefixes MUST come before shorter ones (e.g., "gap-x" before "gap")
+ * to ensure correct matching in parseSpacingUtility.
+ */
+export const SPACING_PREFIXES = [
+  // Padding
+  "px",
+  "py",
+  "pt",
+  "pr",
+  "pb",
+  "pl",
+  "p",
+  // Margin
+  "mx",
+  "my",
+  "mt",
+  "mr",
+  "mb",
+  "ml",
+  "m",
+  // Gap - longer prefixes first!
+  "gap-x",
+  "gap-y",
+  "gap",
+  // Space between
+  "space-x",
+  "space-y",
+  // Dimensions (from suggest.ts) - longer prefixes first!
+  "min-w",
+  "min-h",
+  "max-w",
+  "max-h",
+  "w",
+  "h",
+] as const;
+
+// ============================================================================
+// Constants - Color Utilities
+// ============================================================================
+
+/**
+ * All color-related utility prefixes.
+ * Includes 'outline' which was previously missing in some files.
+ */
+export const COLOR_PREFIXES = [
+  "bg",
+  "text",
+  "border",
+  "ring",
+  "fill",
+  "stroke",
+  "outline", // Was only in suggest.ts, now unified
+] as const;
+
+/**
+ * Raw color values that are valid without a palette prefix.
+ */
+export const RAW_COLOR_VALUES = new Set(["transparent", "current", "black", "white", "inherit"]);
+
+/**
+ * Regex to match Tailwind palette color values like "blue-500", "gray-100".
+ */
+export const PALETTE_VALUE_REGEX = /^[a-z-]+-\d{2,3}$/i;
+
+/**
+ * Regex to extract CSS variable references from color values.
+ */
+export const VAR_COLOR_TOKEN_REGEX = /var\(\s*(--color-[A-Za-z0-9-_]+)\s*(?:,[^)]+)?\)/i;
+
+/**
+ * Regex to detect color literals inside arbitrary value brackets.
+ * Used to distinguish color values from typography values.
+ */
+export const COLOR_LITERAL_REGEX =
+  /^#[0-9a-f]{3,8}$|^rgb|^rgba|^hsl|^hsla|^oklch|^lab|^lch|^color\(/i;
+
+// ============================================================================
+// Constants - Typography Utilities
+// ============================================================================
+
+/**
+ * Typography utility prefixes.
+ */
+export const TYPOGRAPHY_PREFIXES = ["text", "font", "leading", "tracking"] as const;
+
+/**
+ * Valid text size values (text-sm, text-lg, etc).
+ */
+export const TYPOGRAPHY_SIZE_VALUES = new Set([
+  "xs",
+  "sm",
+  "base",
+  "lg",
+  "xl",
+  "2xl",
+  "3xl",
+  "4xl",
+  "5xl",
+  "6xl",
+  "7xl",
+  "8xl",
+  "9xl",
+]);
+
+/**
+ * Valid font weight values (font-bold, font-semibold, etc).
+ */
+export const FONT_WEIGHT_VALUES = new Set([
+  "thin",
+  "extralight",
+  "light",
+  "normal",
+  "medium",
+  "semibold",
+  "bold",
+  "extrabold",
+  "black",
+]);
+
+/**
+ * Valid font family values (font-sans, font-serif, font-mono).
+ * This was missing in previous implementations - PR #92 feedback.
+ */
+export const FONT_FAMILY_VALUES = new Set(["sans", "serif", "mono"]);
+
+/**
+ * Valid leading (line-height) values.
+ */
+export const LEADING_VALUES = new Set(["none", "tight", "snug", "normal", "relaxed", "loose"]);
+
+/**
+ * Valid tracking (letter-spacing) values.
+ */
+export const TRACKING_VALUES = new Set(["tighter", "tight", "normal", "wide", "wider", "widest"]);
+
+// ============================================================================
+// Core Parsing Functions
+// ============================================================================
+
+/**
+ * Split a string by a delimiter, respecting bracket and parenthesis depth.
+ * This handles arbitrary values like `text-[calc(100%-20px)]` correctly.
+ *
+ * @example
+ * splitByDelimiter("hover:text-blue-500", ":") // ["hover", "text-blue-500"]
+ * splitByDelimiter("text-[calc(1:2)]", ":") // ["text-[calc(1:2)]"]
+ */
+export function splitByDelimiter(input: string, delimiter: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let bracketDepth = 0;
+  let parenDepth = 0;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+    if (!char) continue;
+
+    if (char === "[") bracketDepth += 1;
+    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
+    else if (char === "(") parenDepth += 1;
+    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
+
+    if (char === delimiter && bracketDepth === 0 && parenDepth === 0) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  parts.push(current);
+  return parts;
+}
+
+/**
+ * Extract the utility segment from a class name, removing responsive/state prefixes.
+ *
+ * @example
+ * getUtilitySegment("hover:md:text-blue-500") // "text-blue-500"
+ * getUtilitySegment("text-blue-500") // "text-blue-500"
+ */
+export function getUtilitySegment(className: string): string {
+  const parts = splitByDelimiter(className, ":");
+  return parts[parts.length - 1] ?? className;
+}
+
+// ============================================================================
+// Parsed Utility Types
+// ============================================================================
+
+export interface ParsedUtility {
+  prefix: string;
+  value: string;
+}
+
+export type UtilityCategory = "color" | "spacing" | "typography" | "other";
+
+export interface ClassificationResult {
+  category: UtilityCategory;
+  parsed: ParsedUtility | null;
+  isArbitrary: boolean;
+  isTokenized: boolean;
+}
+
+// ============================================================================
+// Color Detection & Parsing
+// ============================================================================
+
+/**
+ * Check if a value inside brackets represents a color literal.
+ * Used to distinguish `text-[#fff]` (color) from `text-[14px]` (typography).
+ *
+ * This fixes PR #92 feedback where `text-[#fff]` was misclassified as typography.
+ */
+export function isColorLiteralValue(value: string): boolean {
+  // Raw color keywords
+  if (RAW_COLOR_VALUES.has(value)) return true;
+
+  // Arbitrary color value in brackets
+  if (value.startsWith("[")) {
+    const inner = value.slice(1, -1).toLowerCase();
+    // Check for color functions and hex values
+    if (COLOR_LITERAL_REGEX.test(inner)) return true;
+    // Check for var(--color-*) references
+    if (/var\(--/.test(inner)) return true;
+    return false;
+  }
+
+  // Palette value like "blue-500"
+  return PALETTE_VALUE_REGEX.test(value);
+}
+
+/**
+ * Parse a color utility class name.
+ *
+ * @example
+ * parseColorUtility("bg-blue-500") // { prefix: "bg", value: "blue-500" }
+ * parseColorUtility("text-[#fff]") // { prefix: "text", value: "[#fff]" }
+ * parseColorUtility("text-lg") // null (typography, not color)
+ */
+export function parseColorUtility(className: string): ParsedUtility | null {
+  const utility = getUtilitySegment(className);
+
+  for (const prefix of COLOR_PREFIXES) {
+    if (utility.startsWith(`${prefix}-`)) {
+      const value = utility.slice(prefix.length + 1);
+
+      // Special case for 'text-' prefix: distinguish color from typography
+      if (prefix === "text") {
+        // If it's a typography value, not a color
+        if (isTypographySizeValue(value)) return null;
+        // If it's an arbitrary value, check if it's a color literal
+        if (value.startsWith("[") && !isColorLiteralValue(value)) return null;
+      }
+
+      return { prefix, value };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract a CSS color token reference from a value.
+ *
+ * @example
+ * extractVarColorToken("[var(--color-primary)]") // "--color-primary"
+ * extractVarColorToken("primary") // null
+ */
+export function extractVarColorToken(value: string): string | null {
+  const inner = value.startsWith("[") ? value.slice(1, -1) : value;
+  const match = inner.match(VAR_COLOR_TOKEN_REGEX);
+  return match?.[1] ?? null;
+}
+
+// ============================================================================
+// Spacing Detection & Parsing
+// ============================================================================
+
+/**
+ * Parse a spacing utility class name.
+ *
+ * @example
+ * parseSpacingUtility("p-4") // { prefix: "p", value: "4" }
+ * parseSpacingUtility("gap-x-2") // { prefix: "gap-x", value: "2" }
+ * parseSpacingUtility("text-lg") // null
+ */
+export function parseSpacingUtility(className: string): ParsedUtility | null {
+  const utility = getUtilitySegment(className);
+
+  for (const prefix of SPACING_PREFIXES) {
+    if (utility.startsWith(`${prefix}-`)) {
+      return {
+        prefix,
+        value: utility.slice(prefix.length + 1),
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Check if a class name is a spacing utility.
+ */
+export function isSpacingUtility(className: string): boolean {
+  const utility = getUtilitySegment(className);
+  for (const prefix of SPACING_PREFIXES) {
+    if (utility.startsWith(`${prefix}-`) || utility === prefix) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ============================================================================
+// Typography Detection & Parsing
+// ============================================================================
+
+/**
+ * Check if a value is a valid typography size value.
+ * This includes scale values (xs, sm, lg, etc) and numeric/arbitrary sizes.
+ */
+function isTypographySizeValue(value: string): boolean {
+  // Scale values
+  if (TYPOGRAPHY_SIZE_VALUES.has(value)) return true;
+  // Numeric values like "14" or "1.5"
+  if (/^\d+(\.\d+)?$/.test(value)) return true;
+  return false;
+}
+
+/**
+ * Check if a value is a valid typography text value.
+ * This rejects color literals like `#fff` - fixing PR #92 feedback.
+ *
+ * @example
+ * isTypographyTextValue("lg") // true
+ * isTypographyTextValue("[14px]") // true
+ * isTypographyTextValue("[#fff]") // false - this is a color!
+ * isTypographyTextValue("(--text-size)") // true - token reference
+ */
+export function isTypographyTextValue(value: string): boolean {
+  // Scale values
+  if (TYPOGRAPHY_SIZE_VALUES.has(value)) return true;
+
+  // Arbitrary value in brackets - but NOT if it's a color literal
+  if (value.startsWith("[")) {
+    // Reject color literals inside brackets
+    if (isColorLiteralValue(value)) return false;
+    return true;
+  }
+
+  // Token reference via shorthand syntax
+  if (value.startsWith("(--")) return true;
+
+  // Numeric values like "14" or "1.5"
+  if (/^\d+(\.\d+)?$/.test(value)) return true;
+
+  return false;
+}
+
+/**
+ * Check if a value is a valid font utility value (weight or family).
+ */
+function isFontUtilityValue(value: string): boolean {
+  // Font weight values
+  if (FONT_WEIGHT_VALUES.has(value)) return true;
+  // Font family values (sans, serif, mono) - PR #92 fix
+  if (FONT_FAMILY_VALUES.has(value)) return true;
+  // Arbitrary value
+  if (value.startsWith("[")) return true;
+  // Token reference
+  if (value.startsWith("(--")) return true;
+  return false;
+}
+
+/**
+ * Parse a typography utility class name.
+ *
+ * @example
+ * parseTypographyUtility("text-lg") // { prefix: "text", value: "lg" }
+ * parseTypographyUtility("font-bold") // { prefix: "font", value: "bold" }
+ * parseTypographyUtility("font-sans") // { prefix: "font", value: "sans" }
+ * parseTypographyUtility("text-[#fff]") // null - this is a color!
+ */
+export function parseTypographyUtility(className: string): ParsedUtility | null {
+  const utility = getUtilitySegment(className);
+
+  // text-* utilities (size)
+  if (utility.startsWith("text-")) {
+    const value = utility.slice(5);
+    if (isTypographyTextValue(value)) {
+      return { prefix: "text", value };
+    }
+    return null;
+  }
+
+  // font-* utilities (weight, family)
+  if (utility.startsWith("font-")) {
+    const value = utility.slice(5);
+    if (isFontUtilityValue(value)) {
+      return { prefix: "font", value };
+    }
+    return null;
+  }
+
+  // leading-* utilities (line-height)
+  if (utility.startsWith("leading-")) {
+    const value = utility.slice(8);
+    if (
+      LEADING_VALUES.has(value) ||
+      value.startsWith("[") ||
+      value.startsWith("(--") ||
+      /^\d+(\.\d+)?$/.test(value)
+    ) {
+      return { prefix: "leading", value };
+    }
+    return null;
+  }
+
+  // tracking-* utilities (letter-spacing)
+  if (utility.startsWith("tracking-")) {
+    const value = utility.slice(9);
+    if (TRACKING_VALUES.has(value) || value.startsWith("[") || value.startsWith("(--")) {
+      return { prefix: "tracking", value };
+    }
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * Check if a class name is a typography utility.
+ */
+export function isTypographyUtility(className: string): boolean {
+  return parseTypographyUtility(className) !== null;
+}
+
+/**
+ * Check if a class name is a color utility.
+ */
+export function isColorUtility(className: string): boolean {
+  return parseColorUtility(className) !== null;
+}
+
+// ============================================================================
+// Token Resolution
+// ============================================================================
+
+/**
+ * Resolve a class name to its underlying CSS token, if any.
+ *
+ * @example
+ * resolveClassToToken("bg-primary") // "--color-primary"
+ * resolveClassToToken("p-(--spacing-md)") // "--spacing-md"
+ * resolveClassToToken("p-4") // null
+ */
+export function resolveClassToToken(className: string): string | null {
+  const utility = getUtilitySegment(className);
+
+  // Shorthand token syntax: prefix-(--token-name)
+  const shorthandMatch = utility.match(/^[A-Za-z-]+-\((--[A-Za-z0-9-_]+)\)$/);
+  if (shorthandMatch?.[1]) {
+    return shorthandMatch[1];
+  }
+
+  // Color utility: infer token from semantic name
+  const colorMatch = utility.match(
+    /^(bg|text|border|ring|fill|stroke|outline)-([A-Za-z0-9-_]+)(?:\/[\d.]+)?$/
+  );
+  if (colorMatch?.[2]) {
+    const value = colorMatch[2];
+    // Don't resolve palette colors (blue-500) - only semantic names
+    if (PALETTE_VALUE_REGEX.test(value)) {
+      return null;
+    }
+    // Don't resolve typography values (lg, sm, base, etc.) as color tokens
+    // This fixes the issue where text-lg was incorrectly resolved to --color-lg
+    if (TYPOGRAPHY_SIZE_VALUES.has(value)) {
+      return null;
+    }
+    return `--color-${value}`;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a class name to its underlying CSS token, validating against known tokens.
+ * This version checks that the resolved token actually exists in the token set.
+ */
+export function resolveClassToTokenValidated(
+  className: string,
+  tokenNames: Set<string>
+): string | null {
+  const utility = getUtilitySegment(className);
+
+  // Shorthand token syntax
+  const shorthandMatch = utility.match(/^[A-Za-z-]+-\((--[A-Za-z0-9-_]+)\)$/);
+  if (shorthandMatch?.[1]) {
+    return shorthandMatch[1];
+  }
+
+  // Color utility with validation
+  const colorMatch = utility.match(
+    /^(bg|text|border|ring|fill|stroke|outline)-([A-Za-z0-9-_]+)(?:\/[\d.]+)?$/
+  );
+  if (colorMatch?.[2]) {
+    const tokenName = `--color-${colorMatch[2]}`;
+    if (tokenNames.has(tokenName)) {
+      return tokenName;
+    }
+    return null;
+  }
+
+  return null;
+}
+
+// ============================================================================
+// High-Level Classification
+// ============================================================================
+
+/**
+ * Classify a utility class name into its category.
+ *
+ * @example
+ * classifyUtility("bg-blue-500") // { category: "color", ... }
+ * classifyUtility("p-4") // { category: "spacing", ... }
+ * classifyUtility("text-lg") // { category: "typography", ... }
+ * classifyUtility("text-[#fff]") // { category: "color", ... }
+ */
+export function classifyUtility(className: string): ClassificationResult {
+  const utility = getUtilitySegment(className);
+
+  // Check for color utilities first (including text-[#color])
+  const colorParsed = parseColorUtility(className);
+  if (colorParsed) {
+    return {
+      category: "color",
+      parsed: colorParsed,
+      isArbitrary: colorParsed.value.startsWith("["),
+      isTokenized:
+        colorParsed.value.startsWith("(--") || extractVarColorToken(colorParsed.value) !== null,
+    };
+  }
+
+  // Check for spacing utilities
+  const spacingParsed = parseSpacingUtility(className);
+  if (spacingParsed) {
+    return {
+      category: "spacing",
+      parsed: spacingParsed,
+      isArbitrary: spacingParsed.value.includes("["),
+      isTokenized: spacingParsed.value.includes("--"),
+    };
+  }
+
+  // Check for typography utilities
+  const typographyParsed = parseTypographyUtility(className);
+  if (typographyParsed) {
+    return {
+      category: "typography",
+      parsed: typographyParsed,
+      isArbitrary: typographyParsed.value.startsWith("["),
+      isTokenized: typographyParsed.value.startsWith("(--"),
+    };
+  }
+
+  // Unknown utility
+  return {
+    category: "other",
+    parsed: null,
+    isArbitrary: utility.includes("["),
+    isTokenized: utility.includes("--"),
+  };
+}
+
+/**
+ * Categorize a pattern of classes for adoption analysis.
+ * Returns "mixed" if classes span multiple categories.
+ */
+export function categorizePattern(classes: string[]): "color" | "spacing" | "typography" | "mixed" {
+  if (classes.length === 0) return "mixed";
+
+  let colorCount = 0;
+  let spacingCount = 0;
+  let typographyCount = 0;
+
+  for (const className of classes) {
+    const result = classifyUtility(className);
+    if (result.category === "color") colorCount += 1;
+    else if (result.category === "spacing") spacingCount += 1;
+    else if (result.category === "typography") typographyCount += 1;
+  }
+
+  const total = classes.length;
+
+  if (colorCount === total) return "color";
+  if (spacingCount === total) return "spacing";
+  if (typographyCount === total) return "typography";
+
+  return "mixed";
+}
+
+// ============================================================================
+// Arbitrary Value Detection
+// ============================================================================
+
+/**
+ * Check if a class contains an arbitrary color value.
+ */
+export function isArbitraryColorUtility(className: string): boolean {
+  const utility = getUtilitySegment(className);
+  return /^(bg|text|border|ring|fill|stroke|outline)-\[(#|rgb|rgba|hsl|hsla|oklch|lab|lch)/.test(
+    utility
+  );
+}
+
+/**
+ * Check if a class contains an arbitrary value violation.
+ * Returns true for arbitrary values that don't use CSS variables.
+ */
+export function isArbitraryValueViolation(className: string): boolean {
+  const utility = getUtilitySegment(className);
+
+  if (!utility.includes("[") || !utility.includes("]")) {
+    return false;
+  }
+
+  // Not a violation if using a CSS variable
+  if (utility.includes("var(--")) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
Add typography usage discovery command parallel to spacing. Parses
text-*, font-*, leading-*, and tracking-* utilities, distinguishing
typography text-* classes from color utilities.

- Add TYPOGRAPHY_PREFIXES: text, font, leading, tracking
- Add parseTypographyUtility with validation for each prefix
- Add buildTypographyUsage for value/utility aggregation
- Support tokenized, arbitrary, and scale categorization
- Add --typography CLI option with JSON output support
- Add comprehensive unit tests (14 tests, all passing)

Closes #78

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>