### PR TITLE
feat(mcp): add dynamic tool updates (#74)

### DIFF
--- a/packages/north/src/mcp/server.test.ts
+++ b/packages/north/src/mcp/server.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { TIERED_TOOLS, getGuidance, getToolsForState } from "./server.ts";
+
+describe("getToolsForState", () => {
+  test("returns only tier 1 tools for state 'none'", () => {
+    const tools = getToolsForState("none");
+
+    expect(tools.length).toBeGreaterThan(0);
+    expect(tools.every((t) => t.tier === 1)).toBe(true);
+    expect(tools.some((t) => t.name === "north_status")).toBe(true);
+  });
+
+  test("returns tier 1 and 2 tools for state 'config'", () => {
+    const tools = getToolsForState("config");
+
+    // Should include tier 1 and 2 tools
+    const tier1Tools = tools.filter((t) => t.tier === 1);
+    const tier2Tools = tools.filter((t) => t.tier === 2);
+    const tier3Tools = tools.filter((t) => t.tier === 3);
+
+    expect(tier1Tools.length).toBeGreaterThan(0);
+    expect(tier2Tools.length).toBeGreaterThan(0);
+    expect(tier3Tools.length).toBe(0);
+
+    // Verify expected tools are present
+    expect(tools.some((t) => t.name === "north_status")).toBe(true);
+    expect(tools.some((t) => t.name === "north_context")).toBe(true);
+    expect(tools.some((t) => t.name === "north_check")).toBe(true);
+    expect(tools.some((t) => t.name === "north_suggest")).toBe(true);
+
+    // Verify tier 3 tools are not present
+    expect(tools.some((t) => t.name === "north_discover")).toBe(false);
+    expect(tools.some((t) => t.name === "north_promote")).toBe(false);
+  });
+
+  test("returns all tools for state 'indexed'", () => {
+    const tools = getToolsForState("indexed");
+
+    // Should include all tiers
+    const tier1Tools = tools.filter((t) => t.tier === 1);
+    const tier2Tools = tools.filter((t) => t.tier === 2);
+    const tier3Tools = tools.filter((t) => t.tier === 3);
+
+    expect(tier1Tools.length).toBeGreaterThan(0);
+    expect(tier2Tools.length).toBeGreaterThan(0);
+    expect(tier3Tools.length).toBeGreaterThan(0);
+
+    // All defined tools should be available
+    expect(tools.length).toBe(TIERED_TOOLS.length);
+  });
+});
+
+describe("TIERED_TOOLS", () => {
+  test("has north_status as tier 1", () => {
+    const statusTool = TIERED_TOOLS.find((t) => t.name === "north_status");
+    expect(statusTool).toBeDefined();
+    expect(statusTool?.tier).toBe(1);
+  });
+
+  test("has context, check, suggest as tier 2", () => {
+    const tier2Names = ["north_context", "north_check", "north_suggest"];
+
+    for (const name of tier2Names) {
+      const tool = TIERED_TOOLS.find((t) => t.name === name);
+      expect(tool).toBeDefined();
+      expect(tool?.tier).toBe(2);
+    }
+  });
+
+  test("has discover, promote, refactor, query as tier 3", () => {
+    const tier3Names = ["north_discover", "north_promote", "north_refactor", "north_query"];
+
+    for (const name of tier3Names) {
+      const tool = TIERED_TOOLS.find((t) => t.name === name);
+      expect(tool).toBeDefined();
+      expect(tool?.tier).toBe(3);
+    }
+  });
+
+  test("all tools have descriptions", () => {
+    for (const tool of TIERED_TOOLS) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description.length).toBeGreaterThan(10);
+    }
+  });
+});
+
+describe("getGuidance", () => {
+  test("returns init guidance for state 'none'", () => {
+    const guidance = getGuidance("none");
+
+    expect(guidance.length).toBeGreaterThan(0);
+    expect(guidance.some((g) => g.includes("north init"))).toBe(true);
+  });
+
+  test("returns index guidance for state 'config'", () => {
+    const guidance = getGuidance("config");
+
+    expect(guidance.length).toBeGreaterThan(0);
+    expect(guidance.some((g) => g.includes("north index"))).toBe(true);
+  });
+
+  test("returns full functionality message for state 'indexed'", () => {
+    const guidance = getGuidance("indexed");
+
+    expect(guidance.length).toBeGreaterThan(0);
+    expect(guidance.some((g) => g.includes("Full functionality"))).toBe(true);
+  });
+});

--- a/packages/north/src/mcp/state.test.ts
+++ b/packages/north/src/mcp/state.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { detectContext, detectProjectState, getConfigPath, getIndexPath } from "./state.ts";
+
+describe("detectProjectState", () => {
+  const testDir = resolve(import.meta.dir, ".test-fixtures");
+
+  beforeEach(async () => {
+    // Create fresh test directory
+    await rm(testDir, { recursive: true, force: true });
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    // Cleanup
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  test("returns 'none' when no config file exists", async () => {
+    const state = await detectProjectState(testDir);
+    expect(state).toBe("none");
+  });
+
+  test("returns 'config' when config exists but no index", async () => {
+    // Create north/north.config.yaml
+    const northDir = resolve(testDir, "north");
+    await mkdir(northDir, { recursive: true });
+    await writeFile(
+      resolve(northDir, "north.config.yaml"),
+      "compatibility:\n  tailwind: 4\n  shadcn: 2"
+    );
+
+    const state = await detectProjectState(testDir);
+    expect(state).toBe("config");
+  });
+
+  test("returns 'indexed' when both config and index exist", async () => {
+    // Create north/north.config.yaml
+    const northDir = resolve(testDir, "north");
+    await mkdir(northDir, { recursive: true });
+    await writeFile(
+      resolve(northDir, "north.config.yaml"),
+      "compatibility:\n  tailwind: 4\n  shadcn: 2"
+    );
+
+    // Create .north/index.db
+    const indexDir = resolve(testDir, ".north");
+    await mkdir(indexDir, { recursive: true });
+    await writeFile(resolve(indexDir, "index.db"), "fake-db-content");
+
+    const state = await detectProjectState(testDir);
+    expect(state).toBe("indexed");
+  });
+});
+
+describe("detectContext", () => {
+  const testDir = resolve(import.meta.dir, ".test-fixtures-context");
+
+  beforeEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  test("returns state 'none' and cwd when no config exists", async () => {
+    const ctx = await detectContext(testDir);
+
+    expect(ctx.state).toBe("none");
+    expect(ctx.cwd).toBe(testDir);
+    expect(ctx.configPath).toBeUndefined();
+    expect(ctx.indexPath).toBeUndefined();
+  });
+
+  test("returns state 'config' with configPath when config exists", async () => {
+    const northDir = resolve(testDir, "north");
+    await mkdir(northDir, { recursive: true });
+    const configPath = resolve(northDir, "north.config.yaml");
+    await writeFile(configPath, "compatibility:\n  tailwind: 4");
+
+    const ctx = await detectContext(testDir);
+
+    expect(ctx.state).toBe("config");
+    expect(ctx.cwd).toBe(testDir);
+    expect(ctx.configPath).toBe(configPath);
+    expect(ctx.indexPath).toBeUndefined();
+  });
+
+  test("returns state 'indexed' with both paths when both exist", async () => {
+    // Create config
+    const northDir = resolve(testDir, "north");
+    await mkdir(northDir, { recursive: true });
+    const configPath = resolve(northDir, "north.config.yaml");
+    await writeFile(configPath, "compatibility:\n  tailwind: 4");
+
+    // Create index
+    const indexDir = resolve(testDir, ".north");
+    await mkdir(indexDir, { recursive: true });
+    const indexPath = resolve(indexDir, "index.db");
+    await writeFile(indexPath, "fake-db-content");
+
+    const ctx = await detectContext(testDir);
+
+    expect(ctx.state).toBe("indexed");
+    expect(ctx.cwd).toBe(testDir);
+    expect(ctx.configPath).toBe(configPath);
+    expect(ctx.indexPath).toBe(indexPath);
+  });
+});
+
+describe("path helpers", () => {
+  test("getConfigPath returns expected path", () => {
+    const path = getConfigPath("/project");
+    expect(path).toBe("/project/north/north.config.yaml");
+  });
+
+  test("getIndexPath returns expected path", () => {
+    const path = getIndexPath("/project");
+    expect(path).toBe("/project/.north/index.db");
+  });
+});

--- a/packages/north/src/mcp/state.ts
+++ b/packages/north/src/mcp/state.ts
@@ -1,0 +1,76 @@
+/**
+ * MCP Server State Detection
+ *
+ * Detects the current project state based on configuration and index files.
+ * Used to determine which MCP tools should be available.
+ */
+
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { findConfigFile } from "../config/loader.ts";
+import type { NorthMcpContext, ServerState } from "./types.ts";
+
+/**
+ * Check if a file exists at the given path.
+ */
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect the current server state by checking for config and index files.
+ *
+ * States:
+ * - 'none': No north.config.yaml found
+ * - 'config': Config exists, but no index.db
+ * - 'indexed': Both config and index exist
+ */
+export async function detectProjectState(cwd: string): Promise<ServerState> {
+  const configPath = await findConfigFile(cwd);
+  if (!configPath) return "none";
+
+  const indexPath = resolve(cwd, ".north/index.db");
+  const indexExists = await fileExists(indexPath);
+
+  if (indexExists) return "indexed";
+  return "config";
+}
+
+/**
+ * Detect full context including paths to config and index files.
+ */
+export async function detectContext(cwd: string): Promise<NorthMcpContext> {
+  const configPath = await findConfigFile(cwd);
+
+  if (!configPath) {
+    return { state: "none", cwd };
+  }
+
+  const indexPath = resolve(cwd, ".north/index.db");
+  const indexExists = await fileExists(indexPath);
+
+  if (indexExists) {
+    return { state: "indexed", configPath, indexPath, cwd };
+  }
+
+  return { state: "config", configPath, cwd };
+}
+
+/**
+ * Get the expected config file path for a project directory.
+ */
+export function getConfigPath(cwd: string): string {
+  return resolve(cwd, "north/north.config.yaml");
+}
+
+/**
+ * Get the expected index file path for a project directory.
+ */
+export function getIndexPath(cwd: string): string {
+  return resolve(cwd, ".north/index.db");
+}


### PR DESCRIPTION
Implement tiered tool system based on project state detection.

- Add state.ts with detectProjectState and detectContext functions
- Add TIERED_TOOLS array with tier assignments (1/2/3)
- Add getToolsForState() to filter tools by current state
- Export getGuidance() for state-appropriate user guidance

Tool tiers:
- Tier 1 (always): north_status
- Tier 2 (config): north_context, north_check, north_suggest
- Tier 3 (indexed): north_discover, north_promote, north_refactor, north_query

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>