### PR TITLE
feat(mcp): extract north_status tool to separate file

### DIFF
--- a/packages/north/src/mcp/tools/index.ts
+++ b/packages/north/src/mcp/tools/index.ts
@@ -1,0 +1,8 @@
+/**
+ * MCP Tools Index
+ *
+ * Exports all North MCP tools for registration with the server.
+ */
+
+export { executeStatusTool, getGuidance, registerStatusTool } from "./status.ts";
+export type { StatusResponse } from "./status.ts";

--- a/packages/north/src/mcp/tools/status.test.ts
+++ b/packages/north/src/mcp/tools/status.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { executeStatusTool, getGuidance } from "./status.ts";
+
+// Mock the state module
+const mockDetectContext = mock(() =>
+  Promise.resolve({
+    state: "none" as const,
+    cwd: "/test/path",
+  })
+);
+
+mock.module("../state.ts", () => ({
+  detectContext: mockDetectContext,
+}));
+
+describe("getGuidance", () => {
+  test("returns init guidance for state 'none'", () => {
+    const guidance = getGuidance("none");
+
+    expect(guidance.length).toBeGreaterThan(0);
+    expect(guidance.some((g) => g.includes("north init"))).toBe(true);
+  });
+
+  test("returns index guidance for state 'config'", () => {
+    const guidance = getGuidance("config");
+
+    expect(guidance.length).toBeGreaterThan(0);
+    expect(guidance.some((g) => g.includes("north index"))).toBe(true);
+  });
+
+  test("returns full functionality message for state 'indexed'", () => {
+    const guidance = getGuidance("indexed");
+
+    expect(guidance.length).toBeGreaterThan(0);
+    expect(guidance.some((g) => g.includes("Full functionality"))).toBe(true);
+  });
+});
+
+describe("executeStatusTool", () => {
+  beforeEach(() => {
+    mockDetectContext.mockClear();
+  });
+
+  afterEach(() => {
+    mockDetectContext.mockReset();
+  });
+
+  test("returns status with state 'none' when no config found", async () => {
+    mockDetectContext.mockResolvedValue({
+      state: "none",
+      cwd: "/test/project",
+    });
+
+    const status = await executeStatusTool();
+
+    expect(status.state).toBe("none");
+    expect(status.cwd).toBe("/test/project");
+    expect(status.configPath).toBeNull();
+    expect(status.indexPath).toBeNull();
+    expect(status.capabilities.check).toBe(false);
+    expect(status.capabilities.find).toBe(false);
+    expect(status.capabilities.context).toBe(false);
+    expect(status.capabilities.generate).toBe(false);
+  });
+
+  test("returns status with state 'config' when config exists", async () => {
+    mockDetectContext.mockResolvedValue({
+      state: "config",
+      cwd: "/test/project",
+      configPath: "/test/project/north.config.yaml",
+    });
+
+    const status = await executeStatusTool();
+
+    expect(status.state).toBe("config");
+    expect(status.configPath).toBe("/test/project/north.config.yaml");
+    expect(status.indexPath).toBeNull();
+    expect(status.capabilities.check).toBe(true);
+    expect(status.capabilities.find).toBe(false);
+    expect(status.capabilities.context).toBe(true);
+    expect(status.capabilities.generate).toBe(true);
+  });
+
+  test("returns status with state 'indexed' when fully configured", async () => {
+    mockDetectContext.mockResolvedValue({
+      state: "indexed",
+      cwd: "/test/project",
+      configPath: "/test/project/north.config.yaml",
+      indexPath: "/test/project/.north/index.db",
+    });
+
+    const status = await executeStatusTool();
+
+    expect(status.state).toBe("indexed");
+    expect(status.configPath).toBe("/test/project/north.config.yaml");
+    expect(status.indexPath).toBe("/test/project/.north/index.db");
+    expect(status.capabilities.check).toBe(true);
+    expect(status.capabilities.find).toBe(true);
+    expect(status.capabilities.context).toBe(true);
+    expect(status.capabilities.generate).toBe(true);
+  });
+
+  test("includes guidance in response", async () => {
+    mockDetectContext.mockResolvedValue({
+      state: "none",
+      cwd: "/test/project",
+    });
+
+    const status = await executeStatusTool();
+
+    expect(status.guidance).toBeDefined();
+    expect(status.guidance.length).toBeGreaterThan(0);
+    expect(status.guidance.some((g) => g.includes("north init"))).toBe(true);
+  });
+});

--- a/packages/north/src/mcp/tools/status.ts
+++ b/packages/north/src/mcp/tools/status.ts
@@ -1,0 +1,115 @@
+/**
+ * North Status Tool
+ *
+ * MCP tool that reports the current North design system status.
+ * Always available (Tier 1) - works without any configuration.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { detectContext } from "../state.ts";
+import type { ServerState } from "../types.ts";
+
+/**
+ * Get guidance based on current server state.
+ */
+export function getGuidance(state: ServerState): string[] {
+  switch (state) {
+    case "none":
+      return [
+        "No North configuration found.",
+        "Run 'north init' to initialize the project.",
+        "Then run 'north gen' to generate design tokens.",
+      ];
+    case "config":
+      return [
+        "Configuration found but no index.",
+        "Run 'north index' to build the token index for full functionality.",
+        "Use 'north check' to lint for design system violations.",
+        "Use 'north context' to get design system context for LLMs.",
+      ];
+    case "indexed":
+      return [
+        "Full functionality available.",
+        "Use 'north check' to lint for violations.",
+        "Use 'north find' to discover token usage patterns.",
+        "Use 'north context' for design system context.",
+      ];
+  }
+}
+
+/**
+ * Status response structure returned by north_status tool.
+ */
+export interface StatusResponse {
+  /** Current server state (none/config/indexed) */
+  state: ServerState;
+  /** Current working directory */
+  cwd: string;
+  /** Path to north.config.yaml if found */
+  configPath: string | null;
+  /** Path to index.db if found */
+  indexPath: string | null;
+  /** Capability flags based on state */
+  capabilities: {
+    check: boolean;
+    find: boolean;
+    context: boolean;
+    generate: boolean;
+  };
+  /** Guidance messages for the user */
+  guidance: string[];
+}
+
+/**
+ * Execute the north_status tool handler.
+ *
+ * Detects the current project state and returns a status report
+ * including available capabilities and guidance for next steps.
+ */
+export async function executeStatusTool(): Promise<StatusResponse> {
+  const cwd = process.cwd();
+  const ctx = await detectContext(cwd);
+
+  return {
+    state: ctx.state,
+    cwd: ctx.cwd,
+    configPath: ctx.configPath ?? null,
+    indexPath: ctx.indexPath ?? null,
+    capabilities: {
+      check: ctx.state !== "none",
+      find: ctx.state === "indexed",
+      context: ctx.state !== "none",
+      generate: ctx.state !== "none",
+    },
+    guidance: getGuidance(ctx.state),
+  };
+}
+
+/**
+ * Register the north_status tool with the MCP server.
+ *
+ * This is a Tier 1 tool that is always available, regardless of
+ * whether North has been configured in the project.
+ */
+export function registerStatusTool(server: McpServer): void {
+  server.registerTool(
+    "north_status",
+    {
+      description:
+        "Get North design system status. Returns current state (none/config/indexed), " +
+        "available capabilities, and guidance on next steps.",
+    },
+    async () => {
+      const status = await executeStatusTool();
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(status, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}


### PR DESCRIPTION
## Summary

Extracts the `north_status` tool implementation from the main server file into a dedicated module at `tools/status.ts`.

## Changes

- Move status tool logic to separate file for better organization
- Export types and registration function
- No functional changes

## Test Plan

- [x] Typecheck passes
- [x] MCP server starts correctly
- [x] `north_status` tool responds as expected