### PR TITLE
feat(cli): add cascade confidence limits (#79-C)

### DIFF
--- a/packages/north/src/commands/find.ts
+++ b/packages/north/src/commands/find.ts
@@ -979,6 +979,15 @@ export async function find(options: FindOptions = {}): Promise<FindResult> {
             console.log(chalk.dim(`  - ${token}`));
           }
         }
+
+        // Display analysis limits
+        if (result.limits.confidence === "partial") {
+          console.log(chalk.dim("\nAnalysis limits:"));
+          console.log(chalk.yellow(`  Confidence: ${result.limits.confidence}`));
+          if (result.limits.missing && result.limits.missing.length > 0) {
+            console.log(chalk.dim(`  Missing: ${result.limits.missing.join(", ")}`));
+          }
+        }
       }
 
       return { success: true, message: "Cascade trace reported" };


### PR DESCRIPTION
Add CascadeLimits interface to track cascade query completeness:
- confidence: "full" | "partial" based on data availability
- missing: optional array of missing data categories

The limits field helps consumers understand when cascade results
may be incomplete (e.g., no theme variants, no token definition).

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>