### PR TITLE
feat(mcp): implement north_refactor tool (#77)

### DIFF
--- a/packages/north/src/mcp/server.ts
+++ b/packages/north/src/mcp/server.ts
@@ -9,6 +9,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { getGuidance, registerStatusTool } from "./tools/index.ts";
 import { registerContextTool } from "./tools/context.ts";
+import { registerRefactorTool } from "./tools/refactor.ts";
 import type { ServerState } from "./types.ts";
 
 // Re-export getGuidance for backward compatibility with tests
@@ -156,7 +157,8 @@ function registerTools(server: McpServer): void {
   // Tier 2: Config-dependent tools
   registerContextTool(server);
 
-  // Tier 3 tools will be added in future commits
+  // Tier 3: Index-dependent tools
+  registerRefactorTool(server);
 }
 
 // ============================================================================

--- a/packages/north/src/mcp/tools/index.ts
+++ b/packages/north/src/mcp/tools/index.ts
@@ -6,3 +6,14 @@
 
 export { executeStatusTool, getGuidance, registerStatusTool } from "./status.ts";
 export type { StatusResponse } from "./status.ts";
+
+export { registerContextTool, executeContextTool, type ContextPayload } from "./context.ts";
+
+export {
+  registerRefactorTool,
+  executeRefactorTool,
+  type RefactorResponse,
+  type RefactorCandidate,
+  type RefactorSummary,
+  type RefactorOptions,
+} from "./refactor.ts";

--- a/packages/north/src/mcp/tools/refactor.test.ts
+++ b/packages/north/src/mcp/tools/refactor.test.ts
@@ -1,0 +1,326 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { type RefactorResponse, executeRefactorTool } from "./refactor.ts";
+
+describe("executeRefactorTool", () => {
+  const testDir = resolve(import.meta.dir, ".test-fixtures-refactor-tool");
+
+  beforeEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function setupProject() {
+    // Create north/north.config.yaml
+    const northDir = resolve(testDir, "north");
+    const rulesDir = resolve(northDir, "rules");
+    await mkdir(rulesDir, { recursive: true });
+
+    const configPath = resolve(northDir, "north.config.yaml");
+    await writeFile(
+      configPath,
+      `
+compatibility:
+  tailwind: "4"
+rules:
+  no-raw-palette: error
+  no-arbitrary-colors: error
+`
+    );
+
+    // Create a minimal rule file
+    await writeFile(
+      resolve(rulesDir, "no-raw-palette.yaml"),
+      `id: north/no-raw-palette
+language: tsx
+severity: error
+message: "Use semantic color tokens instead of raw Tailwind palette colors"
+rule:
+  kind: string_fragment
+  regex: "(bg|text|border|ring|fill|stroke)-(red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|zinc|neutral|stone)-\\\\d+(?:\\\\/\\\\d+)?"
+note: |
+  Replace with semantic token:
+  - bg-blue-500 -> bg-primary
+`
+    );
+
+    await writeFile(
+      resolve(rulesDir, "no-arbitrary-colors.yaml"),
+      `id: north/no-arbitrary-colors
+language: tsx
+severity: error
+message: "Use semantic color tokens instead of arbitrary color values"
+rule:
+  kind: string_fragment
+  regex: "(bg|text|border|ring|fill|stroke)-\\\\[(#|rgb|rgba|hsl|hsla|oklch|lab|lch)[^\\\\]]+\\\\]"
+note: |
+  Prohibited: bg-[#ff0000], text-[rgb(0,0,0)]
+  Use semantic tokens: bg-destructive, text-foreground
+`
+    );
+
+    return configPath;
+  }
+
+  test("returns empty candidates when no violations found", async () => {
+    const configPath = await setupProject();
+
+    // Create a clean component
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      resolve(srcDir, "Button.tsx"),
+      `export function Button() {
+  return <button className="bg-primary text-foreground">Click</button>;
+}`
+    );
+
+    const response = await executeRefactorTool(testDir, configPath, {
+      scope: "all",
+      dryRun: true,
+      limit: 20,
+    });
+
+    expect(response.scope).toBe("all");
+    expect(response.candidates).toBeInstanceOf(Array);
+    expect(response.summary.totalCandidates).toBe(0);
+  });
+
+  test("identifies color violations as candidates", async () => {
+    const configPath = await setupProject();
+
+    // Create component with raw palette colors
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      resolve(srcDir, "Card.tsx"),
+      `export function Card() {
+  return (
+    <div className="bg-blue-500 text-gray-600 border-slate-200">
+      Card content
+    </div>
+  );
+}`
+    );
+
+    const response = await executeRefactorTool(testDir, configPath, {
+      scope: "colors",
+      dryRun: true,
+      limit: 20,
+    });
+
+    expect(response.scope).toBe("colors");
+    expect(response.candidates.length).toBeGreaterThan(0);
+    expect(response.summary.totalCandidates).toBeGreaterThan(0);
+
+    // Check that candidates have required fields
+    const candidate = response.candidates[0];
+    expect(candidate).toHaveProperty("file");
+    expect(candidate).toHaveProperty("line");
+    expect(candidate).toHaveProperty("column");
+    expect(candidate).toHaveProperty("currentValue");
+    expect(candidate).toHaveProperty("suggestedToken");
+    expect(candidate).toHaveProperty("confidence");
+    expect(candidate).toHaveProperty("context");
+  });
+
+  test("respects limit parameter", async () => {
+    const configPath = await setupProject();
+
+    // Create component with many violations
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      resolve(srcDir, "ManyColors.tsx"),
+      `export function ManyColors() {
+  return (
+    <div className="bg-blue-500 text-gray-600 border-slate-200 bg-red-400 text-green-500">
+      <span className="bg-yellow-300 text-purple-700 border-pink-200">Content</span>
+    </div>
+  );
+}`
+    );
+
+    const response = await executeRefactorTool(testDir, configPath, {
+      scope: "all",
+      dryRun: true,
+      limit: 3,
+    });
+
+    expect(response.candidates.length).toBeLessThanOrEqual(3);
+  });
+
+  test("filters by scope - colors only", async () => {
+    const configPath = await setupProject();
+
+    // Create component with color violations
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      resolve(srcDir, "Mixed.tsx"),
+      `export function Mixed() {
+  return <div className="bg-blue-500 p-4">Content</div>;
+}`
+    );
+
+    const response = await executeRefactorTool(testDir, configPath, {
+      scope: "colors",
+      dryRun: true,
+      limit: 20,
+    });
+
+    expect(response.scope).toBe("colors");
+    // Should only find color violations, not spacing
+    for (const candidate of response.candidates) {
+      expect(candidate.currentValue).toMatch(
+        /(bg|text|border|ring|fill|stroke)-(red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|zinc|neutral|stone)-\d+/
+      );
+    }
+  });
+
+  test("includes byType breakdown in summary", async () => {
+    const configPath = await setupProject();
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      resolve(srcDir, "Types.tsx"),
+      `export function Types() {
+  return <div className="bg-blue-500 text-gray-600">Content</div>;
+}`
+    );
+
+    const response = await executeRefactorTool(testDir, configPath, {
+      scope: "all",
+      dryRun: true,
+      limit: 20,
+    });
+
+    expect(response.summary).toHaveProperty("byType");
+    expect(typeof response.summary.byType).toBe("object");
+  });
+
+  test("includes estimatedImpact in summary", async () => {
+    const configPath = await setupProject();
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      resolve(srcDir, "Impact.tsx"),
+      `export function Impact() {
+  return <div className="bg-blue-500">Content</div>;
+}`
+    );
+
+    const response = await executeRefactorTool(testDir, configPath, {
+      scope: "all",
+      dryRun: true,
+      limit: 20,
+    });
+
+    expect(response.summary).toHaveProperty("estimatedImpact");
+    expect(typeof response.summary.estimatedImpact).toBe("string");
+  });
+
+  test("returns totalFiles count", async () => {
+    const configPath = await setupProject();
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      resolve(srcDir, "File1.tsx"),
+      "export function File1() { return <div>1</div>; }"
+    );
+    await writeFile(
+      resolve(srcDir, "File2.tsx"),
+      "export function File2() { return <div>2</div>; }"
+    );
+
+    const response = await executeRefactorTool(testDir, configPath, {
+      scope: "all",
+      dryRun: true,
+      limit: 20,
+    });
+
+    expect(response.totalFiles).toBeGreaterThanOrEqual(2);
+  });
+
+  test("assigns confidence levels based on rule severity", async () => {
+    const configPath = await setupProject();
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(
+      resolve(srcDir, "Confidence.tsx"),
+      `export function Confidence() {
+  return <div className="bg-blue-500">Content</div>;
+}`
+    );
+
+    const response = await executeRefactorTool(testDir, configPath, {
+      scope: "all",
+      dryRun: true,
+      limit: 20,
+    });
+
+    // Error severity rules should map to high confidence
+    const candidate = response.candidates.find((c) => c.currentValue.includes("blue-500"));
+    if (candidate) {
+      expect(["high", "medium", "low"]).toContain(candidate.confidence);
+    }
+  });
+});
+
+describe("RefactorResponse structure", () => {
+  const testDir = resolve(import.meta.dir, ".test-fixtures-refactor-response");
+
+  beforeEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  test("has all required fields", async () => {
+    // Create minimal setup
+    const northDir = resolve(testDir, "north");
+    const rulesDir = resolve(northDir, "rules");
+    await mkdir(rulesDir, { recursive: true });
+
+    const configPath = resolve(northDir, "north.config.yaml");
+    await writeFile(configPath, "compatibility:\n  tailwind: '4'");
+
+    await writeFile(
+      resolve(rulesDir, "no-raw-palette.yaml"),
+      `id: north/no-raw-palette
+language: tsx
+severity: error
+message: "Use semantic tokens"
+rule:
+  kind: string_fragment
+  regex: "bg-blue-\\\\d+"
+`
+    );
+
+    const response: RefactorResponse = await executeRefactorTool(testDir, configPath, {
+      scope: "all",
+      dryRun: true,
+      limit: 20,
+    });
+
+    expect(response).toHaveProperty("scope");
+    expect(response).toHaveProperty("totalFiles");
+    expect(response).toHaveProperty("candidates");
+    expect(response).toHaveProperty("summary");
+    expect(response.summary).toHaveProperty("totalCandidates");
+    expect(response.summary).toHaveProperty("byType");
+    expect(response.summary).toHaveProperty("estimatedImpact");
+  });
+});

--- a/packages/north/src/mcp/tools/refactor.ts
+++ b/packages/north/src/mcp/tools/refactor.ts
@@ -1,0 +1,442 @@
+/**
+ * North Refactor MCP Tool
+ *
+ * Identifies candidates for refactoring to use design tokens.
+ * Generates migration plans and suggests token replacements.
+ *
+ * This is a Tier 3 tool - requires index (.north/index.db) to be present.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { runLint } from "../../lint/engine.ts";
+import type { LintIssue, RuleSeverity } from "../../lint/types.ts";
+import { detectContext } from "../state.ts";
+
+// ============================================================================
+// Input Schema
+// ============================================================================
+
+const RefactorScopeSchema = z.enum(["colors", "spacing", "typography", "all"]);
+
+const RefactorInputSchema = z.object({
+  files: z
+    .array(z.string())
+    .optional()
+    .describe("Glob patterns to analyze (default: all indexed files)"),
+  scope: RefactorScopeSchema.optional()
+    .default("all")
+    .describe("Scope of refactoring: colors, spacing, typography, or all"),
+  dryRun: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe("Preview changes without applying (default: true)"),
+  limit: z.number().optional().default(20).describe("Maximum candidates to return (default: 20)"),
+  cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
+});
+
+type RefactorInput = z.infer<typeof RefactorInputSchema>;
+type RefactorScope = z.infer<typeof RefactorScopeSchema>;
+
+// ============================================================================
+// Response Types
+// ============================================================================
+
+export interface RefactorCandidate {
+  file: string;
+  line: number;
+  column: number;
+  currentValue: string;
+  suggestedToken: string;
+  confidence: "high" | "medium" | "low";
+  context: string;
+}
+
+export interface RefactorSummary {
+  totalCandidates: number;
+  byType: Record<string, number>;
+  estimatedImpact: string;
+}
+
+export interface RefactorResponse {
+  scope: string;
+  totalFiles: number;
+  candidates: RefactorCandidate[];
+  summary: RefactorSummary;
+}
+
+// ============================================================================
+// Token Suggestion Mapping
+// ============================================================================
+
+const COLOR_SUGGESTIONS: Record<string, string> = {
+  "blue-500": "primary",
+  "blue-600": "primary",
+  "gray-50": "muted",
+  "gray-100": "muted",
+  "gray-200": "border",
+  "gray-300": "border",
+  "gray-400": "muted-foreground",
+  "gray-500": "muted-foreground",
+  "gray-600": "muted-foreground",
+  "gray-700": "foreground",
+  "gray-800": "foreground",
+  "gray-900": "foreground",
+  "slate-50": "muted",
+  "slate-100": "muted",
+  "slate-200": "border",
+  "slate-300": "border",
+  "slate-400": "muted-foreground",
+  "slate-500": "muted-foreground",
+  "slate-600": "muted-foreground",
+  "slate-700": "foreground",
+  "slate-800": "foreground",
+  "slate-900": "foreground",
+  "red-500": "destructive",
+  "red-600": "destructive",
+  "green-500": "success",
+  "green-600": "success",
+  "yellow-500": "warning",
+  "amber-500": "warning",
+};
+
+function suggestTokenForColor(className: string): string {
+  // Extract the color part (e.g., "blue-500" from "bg-blue-500")
+  const match = className.match(/(bg|text|border|ring|fill|stroke)-(\w+-\d+)/);
+  if (!match) return "semantic-token";
+
+  const [, prefix, colorValue] = match;
+  const suggestion = COLOR_SUGGESTIONS[colorValue ?? ""];
+
+  if (suggestion && prefix) {
+    // Map prefix to semantic equivalent
+    if (prefix === "bg") return `bg-${suggestion}`;
+    if (prefix === "text")
+      return `text-${suggestion === "primary" ? "primary-foreground" : suggestion}`;
+    if (prefix === "border") return `border-${suggestion === "border" ? "border" : suggestion}`;
+    return `${prefix}-${suggestion}`;
+  }
+
+  return "semantic-color-token";
+}
+
+function suggestTokenForSpacing(className: string): string {
+  // Extract spacing value
+  const match = className.match(
+    /(p|px|py|pt|pr|pb|pl|m|mx|my|mt|mr|mb|ml|gap|space-x|space-y)-(\d+(?:\.\d+)?)/
+  );
+  if (!match) return "spacing-token";
+
+  const [, prefix, value] = match;
+  const numValue = Number.parseFloat(value ?? "0");
+
+  // Map to semantic spacing
+  let semanticName: string;
+  if (numValue <= 1) semanticName = "xs";
+  else if (numValue <= 2) semanticName = "sm";
+  else if (numValue <= 4) semanticName = "md";
+  else if (numValue <= 6) semanticName = "lg";
+  else if (numValue <= 8) semanticName = "xl";
+  else semanticName = "2xl";
+
+  return `${prefix}-(--spacing-${semanticName})`;
+}
+
+function suggestToken(className: string, ruleKey: string): string {
+  if (ruleKey === "no-raw-palette" || ruleKey === "no-arbitrary-colors") {
+    return suggestTokenForColor(className);
+  }
+
+  if (ruleKey === "numeric-spacing-in-component") {
+    return suggestTokenForSpacing(className);
+  }
+
+  return "design-token";
+}
+
+// ============================================================================
+// Scope Filtering
+// ============================================================================
+
+const COLOR_RULES = new Set(["no-raw-palette", "no-arbitrary-colors", "no-inline-color"]);
+const SPACING_RULES = new Set(["numeric-spacing-in-component", "no-arbitrary-values"]);
+const TYPOGRAPHY_RULES = new Set<string>(); // Future expansion
+
+// Rules that represent actual refactoring candidates (token replacement)
+const REFACTOR_CANDIDATE_RULES = new Set([...COLOR_RULES, ...SPACING_RULES, ...TYPOGRAPHY_RULES]);
+
+function isRefactorCandidate(issue: LintIssue): boolean {
+  // Only include issues that represent actual token refactoring opportunities
+  return REFACTOR_CANDIDATE_RULES.has(issue.ruleKey);
+}
+
+function isIssueInScope(issue: LintIssue, scope: RefactorScope): boolean {
+  // First, filter to only refactor candidates
+  if (!isRefactorCandidate(issue)) return false;
+
+  if (scope === "all") return true;
+
+  if (scope === "colors") {
+    return COLOR_RULES.has(issue.ruleKey);
+  }
+
+  if (scope === "spacing") {
+    return SPACING_RULES.has(issue.ruleKey);
+  }
+
+  if (scope === "typography") {
+    return TYPOGRAPHY_RULES.has(issue.ruleKey);
+  }
+
+  return false;
+}
+
+// ============================================================================
+// Confidence Mapping
+// ============================================================================
+
+function mapSeverityToConfidence(severity: RuleSeverity): "high" | "medium" | "low" {
+  switch (severity) {
+    case "error":
+      return "high";
+    case "warn":
+      return "medium";
+    default:
+      return "low";
+  }
+}
+
+// ============================================================================
+// Impact Estimation
+// ============================================================================
+
+function estimateImpact(candidateCount: number, fileCount: number): string {
+  if (candidateCount === 0) {
+    return "No refactoring needed - codebase follows design system patterns";
+  }
+
+  const density = fileCount > 0 ? candidateCount / fileCount : 0;
+
+  if (candidateCount <= 5) {
+    return "Low impact - minor cleanup, quick fixes";
+  }
+
+  if (candidateCount <= 20) {
+    return "Medium impact - focused refactoring session recommended";
+  }
+
+  if (density > 3) {
+    return "High impact - systematic refactoring needed, consider incremental approach";
+  }
+
+  return "Significant impact - plan phased migration to design tokens";
+}
+
+// ============================================================================
+// Context Extraction
+// ============================================================================
+
+function extractContext(issue: LintIssue): string {
+  const parts: string[] = [];
+
+  if (issue.className) {
+    parts.push(`className="${issue.className}"`);
+  }
+
+  if (issue.context) {
+    parts.push(`[${issue.context} context]`);
+  }
+
+  return parts.join(" ");
+}
+
+// ============================================================================
+// Core Logic
+// ============================================================================
+
+export interface RefactorOptions {
+  files?: string[];
+  scope?: RefactorScope;
+  dryRun?: boolean;
+  limit?: number;
+}
+
+/**
+ * Execute the north_refactor tool handler.
+ *
+ * Analyzes the codebase for refactoring candidates and generates
+ * a migration plan for converting magic values to design tokens.
+ */
+export async function executeRefactorTool(
+  workingDir: string,
+  configPath: string,
+  options: RefactorOptions = {}
+): Promise<RefactorResponse> {
+  const { files, scope = "all", limit = 20 } = options;
+
+  // Run lint to find violations
+  const { report } = await runLint({
+    cwd: workingDir,
+    configPath,
+    files,
+    collectIssues: true,
+  });
+
+  // Filter issues by scope
+  const scopedIssues = report.issues.filter((issue) => isIssueInScope(issue, scope));
+
+  // Convert issues to candidates
+  const allCandidates: RefactorCandidate[] = scopedIssues.map((issue) => ({
+    file: issue.filePath,
+    line: issue.line,
+    column: issue.column,
+    currentValue: issue.className ?? issue.message,
+    suggestedToken: suggestToken(issue.className ?? "", issue.ruleKey),
+    confidence: mapSeverityToConfidence(issue.severity),
+    context: extractContext(issue),
+  }));
+
+  // Apply limit
+  const candidates = allCandidates.slice(0, limit);
+
+  // Build byType breakdown
+  const byType: Record<string, number> = {};
+  for (const issue of scopedIssues) {
+    const type = issue.ruleKey;
+    byType[type] = (byType[type] ?? 0) + 1;
+  }
+
+  // Calculate unique files with candidates
+  const uniqueFiles = new Set(allCandidates.map((c) => c.file));
+
+  return {
+    scope,
+    totalFiles: report.stats.totalFiles,
+    candidates,
+    summary: {
+      totalCandidates: allCandidates.length,
+      byType,
+      estimatedImpact: estimateImpact(allCandidates.length, uniqueFiles.size),
+    },
+  };
+}
+
+// ============================================================================
+// Tool Registration
+// ============================================================================
+
+/**
+ * Register the north_refactor tool with the MCP server.
+ *
+ * This is a Tier 3 tool - requires index (.north/index.db) to be present.
+ */
+export function registerRefactorTool(server: McpServer): void {
+  server.registerTool(
+    "north_refactor",
+    {
+      description:
+        "Identify and plan refactoring to use design tokens. Finds magic values " +
+        "(raw colors, arbitrary values, inline spacing) and suggests token replacements. " +
+        "Parameters: files (string[]) - glob patterns, scope (colors|spacing|typography|all), " +
+        "dryRun (boolean, default true), limit (number, default 20).",
+    },
+    async (args: unknown) => {
+      const cwd = process.cwd();
+
+      // Validate input
+      const parseResult = RefactorInputSchema.safeParse(args);
+      if (!parseResult.success) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: false,
+                  error: "Invalid input parameters",
+                  details: parseResult.error.issues,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const input: RefactorInput = parseResult.data;
+      const workingDir = input.cwd ?? cwd;
+
+      // Check context state - this tool requires indexed state (Tier 3)
+      const ctx = await detectContext(workingDir);
+      if (ctx.state !== "indexed") {
+        const guidance =
+          ctx.state === "none"
+            ? [
+                "Run 'north init' to initialize the project.",
+                "Then run 'north index' to build the token index.",
+              ]
+            : [
+                "Run 'north index' to build the token index.",
+                "The refactor tool requires the index for full analysis.",
+              ];
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: false,
+                  error: ctx.state === "none" ? "No North configuration found" : "Index not found",
+                  guidance,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      try {
+        const payload = await executeRefactorTool(workingDir, ctx.configPath as string, {
+          files: input.files,
+          scope: input.scope,
+          dryRun: input.dryRun,
+          limit: input.limit,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(payload, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: false,
+                  error: message,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}


### PR DESCRIPTION
Add MCP tool that identifies code for refactoring to design tokens.
Analyzes lint violations and generates migration candidates with
token suggestions and confidence levels.

- Add RefactorInputSchema with scope (colors/spacing/typography/all)
- Filter violations by scope to only include refactor candidates
- Map lint severity to confidence (error=high, warn=medium, info=low)
- Generate token suggestions based on rule type and current value
- Include impact estimation based on candidate count and distribution

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>