### PR TITLE
feat(cli): add north classify command

### DIFF
--- a/packages/north/src/commands/classify.test.ts
+++ b/packages/north/src/commands/classify.test.ts
@@ -1,0 +1,353 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import type { IndexDatabase } from "../index/db.ts";
+import type { LintContext } from "../lint/types.ts";
+import { type ClassifyOptions, classify } from "./classify.ts";
+
+function createTestDb(): IndexDatabase {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE meta (
+      key TEXT PRIMARY KEY,
+      value TEXT
+    );
+
+    CREATE TABLE tokens (
+      name TEXT PRIMARY KEY,
+      value TEXT,
+      file TEXT,
+      line INTEGER,
+      layer INTEGER,
+      computed_value TEXT
+    );
+
+    CREATE TABLE usages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      file TEXT,
+      line INTEGER,
+      column INTEGER,
+      class_name TEXT,
+      resolved_token TEXT,
+      context TEXT,
+      component TEXT
+    );
+
+    CREATE TABLE patterns (
+      hash TEXT PRIMARY KEY,
+      classes TEXT,
+      count INTEGER,
+      locations TEXT
+    );
+
+    CREATE TABLE token_graph (
+      ancestor TEXT,
+      descendant TEXT,
+      depth INTEGER,
+      path TEXT,
+      PRIMARY KEY (ancestor, descendant)
+    );
+
+    CREATE INDEX usages_file_idx ON usages (file);
+  `);
+  return db as unknown as IndexDatabase;
+}
+
+function insertUsage(
+  db: IndexDatabase,
+  file: string,
+  className: string,
+  context: LintContext | null = null
+): void {
+  db.exec(
+    `INSERT INTO usages (file, line, column, class_name, context) VALUES ('${file}', 1, 1, '${className}', ${context ? `'${context}'` : "NULL"})`
+  );
+}
+
+describe("classify", () => {
+  describe("context detection", () => {
+    test("auto-detects primitive context from ui/ directory", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/components/ui/button.tsx", "flex");
+      insertUsage(db, "src/components/ui/input.tsx", "border");
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.files).toHaveLength(2);
+      expect(report.files.every((f) => f.to === "primitive")).toBe(true);
+      expect(report.files.every((f) => f.source === "path")).toBe(true);
+
+      db.close();
+    });
+
+    test("auto-detects primitive context from primitives/ directory", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/primitives/text.tsx", "font-bold");
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.files[0].to).toBe("primitive");
+
+      db.close();
+    });
+
+    test("auto-detects layout context from layouts/ directory", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/layouts/main.tsx", "min-h-screen");
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.files[0].to).toBe("layout");
+
+      db.close();
+    });
+
+    test("auto-detects layout context from templates/ directory", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/templates/blog.tsx", "container");
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.files[0].to).toBe("layout");
+
+      db.close();
+    });
+
+    test("defaults to composed context for other paths", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/components/dashboard.tsx", "grid");
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.files[0].to).toBe("composed");
+
+      db.close();
+    });
+  });
+
+  describe("explicit context option", () => {
+    test("assigns explicit context to all files", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/components/a.tsx", "flex");
+      insertUsage(db, "src/components/b.tsx", "grid");
+
+      const report = await classify({
+        _testDb: db,
+        context: "primitive",
+      } as ClassifyOptions & { _testDb: IndexDatabase });
+
+      expect(report.files.every((f) => f.to === "primitive")).toBe(true);
+      expect(report.files.every((f) => f.source === "explicit")).toBe(true);
+
+      db.close();
+    });
+  });
+
+  describe("file filtering", () => {
+    test("filters by provided glob patterns", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/components/ui/button.tsx", "flex");
+      insertUsage(db, "src/components/dashboard.tsx", "grid");
+      insertUsage(db, "src/pages/home.tsx", "container");
+
+      const report = await classify({
+        _testDb: db,
+        files: ["src/components/ui/**/*.tsx"],
+      } as ClassifyOptions & { _testDb: IndexDatabase });
+
+      expect(report.files).toHaveLength(1);
+      expect(report.files[0].file).toBe("src/components/ui/button.tsx");
+
+      db.close();
+    });
+  });
+
+  describe("from tracking", () => {
+    test("tracks existing context as from value", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/ui/button.tsx", "flex", "composed");
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.files[0].from).toBe("composed");
+      expect(report.files[0].to).toBe("primitive");
+
+      db.close();
+    });
+
+    test("tracks null when no existing context", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/ui/button.tsx", "flex");
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.files[0].from).toBeNull();
+
+      db.close();
+    });
+  });
+
+  describe("summary", () => {
+    test("counts contexts correctly", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/ui/a.tsx", "a");
+      insertUsage(db, "src/ui/b.tsx", "b");
+      insertUsage(db, "src/layouts/c.tsx", "c");
+      insertUsage(db, "src/components/d.tsx", "d");
+      insertUsage(db, "src/components/e.tsx", "e");
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.summary.total).toBe(5);
+      expect(report.summary.primitive).toBe(2);
+      expect(report.summary.layout).toBe(1);
+      expect(report.summary.composed).toBe(2);
+
+      db.close();
+    });
+
+    test("counts changed files when from differs from to", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/ui/a.tsx", "a", "composed"); // will change to primitive
+      insertUsage(db, "src/ui/b.tsx", "b", "primitive"); // no change
+      insertUsage(db, "src/layouts/c.tsx", "c"); // no existing, will be set
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.summary.changed).toBe(2); // a changes, c is new (null -> layout)
+
+      db.close();
+    });
+  });
+
+  describe("apply mode", () => {
+    test("does not modify database in dry-run mode (default)", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/ui/button.tsx", "flex", "composed");
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.applied).toBe(false);
+
+      // Verify database unchanged
+      const row = db
+        .prepare("SELECT context FROM usages WHERE file = ?")
+        .get("src/ui/button.tsx") as {
+        context: string | null;
+      };
+      expect(row.context).toBe("composed");
+
+      db.close();
+    });
+
+    test("updates database when apply is true", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/ui/button.tsx", "flex", "composed");
+
+      const report = await classify({
+        _testDb: db,
+        apply: true,
+      } as ClassifyOptions & { _testDb: IndexDatabase });
+
+      expect(report.applied).toBe(true);
+
+      // Verify database updated
+      const row = db
+        .prepare("SELECT context FROM usages WHERE file = ?")
+        .get("src/ui/button.tsx") as {
+        context: string | null;
+      };
+      expect(row.context).toBe("primitive");
+
+      db.close();
+    });
+  });
+
+  describe("output format", () => {
+    test("returns correct report structure", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/ui/button.tsx", "flex");
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.kind).toBe("classify");
+      expect(report.applied).toBe(false);
+      expect(Array.isArray(report.files)).toBe(true);
+      expect(report.summary).toBeDefined();
+      expect(report.summary.total).toBeGreaterThan(0);
+
+      db.close();
+    });
+
+    test("file entries have required fields", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/ui/button.tsx", "flex");
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+      const file = report.files[0];
+
+      expect(file.file).toBe("src/ui/button.tsx");
+      expect(file.from).toBeNull();
+      expect(file.to).toBe("primitive");
+      expect(file.source).toBe("path");
+
+      db.close();
+    });
+  });
+
+  describe("unique files", () => {
+    test("returns unique files even with multiple usages", async () => {
+      const db = createTestDb();
+      insertUsage(db, "src/ui/button.tsx", "flex");
+      insertUsage(db, "src/ui/button.tsx", "items-center");
+      insertUsage(db, "src/ui/button.tsx", "justify-center");
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.files).toHaveLength(1);
+      expect(report.files[0].file).toBe("src/ui/button.tsx");
+
+      db.close();
+    });
+  });
+
+  describe("empty index", () => {
+    test("returns empty report when no usages", async () => {
+      const db = createTestDb();
+
+      const report = await classify({ _testDb: db } as ClassifyOptions & {
+        _testDb: IndexDatabase;
+      });
+
+      expect(report.files).toHaveLength(0);
+      expect(report.summary.total).toBe(0);
+
+      db.close();
+    });
+  });
+});

--- a/packages/north/src/commands/classify.ts
+++ b/packages/north/src/commands/classify.ts
@@ -1,0 +1,189 @@
+/**
+ * north classify - Set component context classifications
+ *
+ * @see .scratch/mcp-server/12-cli-classify-spec.md for full specification
+ */
+
+import { access } from "node:fs/promises";
+import { resolve } from "node:path";
+import { minimatch } from "minimatch";
+import { findConfigFile, loadConfig } from "../config/loader.ts";
+import { openIndexDatabase } from "../index/db.ts";
+import type { IndexDatabase } from "../index/db.ts";
+import { resolveIndexPath } from "../index/sources.ts";
+import { getContext } from "../lint/context.ts";
+import type { LintContext } from "../lint/types.ts";
+
+export class ClassifyError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = "ClassifyError";
+  }
+}
+
+export interface ClassifyOptions {
+  cwd?: string;
+  config?: string;
+  files?: string[];
+  context?: LintContext;
+  auto?: boolean;
+  comment?: boolean;
+  dryRun?: boolean;
+  apply?: boolean;
+  json?: boolean;
+  quiet?: boolean;
+  /** Internal: test database injection */
+  _testDb?: IndexDatabase;
+}
+
+export interface ClassifyFileEntry {
+  file: string;
+  from: LintContext | null;
+  to: LintContext;
+  source: "explicit" | "auto" | "path" | "default";
+  commentWritten?: boolean;
+}
+
+export interface ClassifyReport {
+  kind: "classify";
+  applied: boolean;
+  files: ClassifyFileEntry[];
+  summary: {
+    total: number;
+    primitive: number;
+    composed: number;
+    layout: number;
+    changed: number;
+  };
+}
+
+interface UsageRow {
+  file: string;
+  context: string | null;
+}
+
+/**
+ * Checks if a file path matches any of the provided glob patterns
+ */
+function matchesGlob(filePath: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => minimatch(filePath, pattern));
+}
+
+/**
+ * Determines context source based on options
+ */
+function getContextSource(options: ClassifyOptions): "explicit" | "auto" | "path" {
+  if (options.context) return "explicit";
+  if (options.auto) return "auto";
+  return "path";
+}
+
+/**
+ * Classifies files and optionally updates their context in the index
+ */
+export async function classify(options: ClassifyOptions = {}): Promise<ClassifyReport> {
+  let db = options._testDb;
+  let shouldCloseDb = false;
+
+  if (!db) {
+    // Open database from config
+    const cwd = options.cwd ?? process.cwd();
+    const configFile = options.config ? resolve(cwd, options.config) : await findConfigFile(cwd);
+
+    if (!configFile) {
+      throw new ClassifyError("No north.config.ts found. Run 'north init' to create one.");
+    }
+
+    const configResult = await loadConfig(configFile);
+    if (!configResult.success) {
+      throw new ClassifyError(`Failed to load config: ${configResult.error}`, configResult.error);
+    }
+
+    const indexPath = resolveIndexPath(cwd, configResult.config);
+
+    // Check if index exists
+    try {
+      await access(indexPath);
+    } catch {
+      throw new ClassifyError(
+        `Index not found at ${indexPath}. Run 'north index' first to build the index.`
+      );
+    }
+
+    db = await openIndexDatabase(indexPath);
+    shouldCloseDb = true;
+  }
+
+  // Query unique files with their current context
+  const rows = db
+    .prepare<[], UsageRow>("SELECT DISTINCT file, context FROM usages")
+    .all() as UsageRow[];
+
+  // Build map of file -> existing context (handle duplicates by taking first non-null)
+  const fileContextMap = new Map<string, LintContext | null>();
+  for (const row of rows) {
+    const existing = fileContextMap.get(row.file);
+    // Update if file not seen yet, or if current is null and new row has context
+    if (existing === undefined || (existing === null && row.context)) {
+      fileContextMap.set(row.file, row.context ? (row.context as LintContext) : null);
+    }
+  }
+
+  // Get unique files
+  let files = Array.from(fileContextMap.keys());
+
+  // Filter by glob patterns if provided
+  if (options.files && options.files.length > 0) {
+    files = files.filter((f) => matchesGlob(f, options.files as string[]));
+  }
+
+  // Determine source type
+  const source = getContextSource(options);
+
+  // Build file entries with classification
+  const fileEntries: ClassifyFileEntry[] = files.map((file) => {
+    const from = fileContextMap.get(file) ?? null;
+    const to = options.context ?? getContext(file);
+
+    return {
+      file,
+      from,
+      to,
+      source,
+    };
+  });
+
+  // Apply changes if requested
+  const shouldApply = options.apply === true;
+
+  if (shouldApply) {
+    const updateStmt = db.prepare<[string, string]>("UPDATE usages SET context = ? WHERE file = ?");
+    for (const entry of fileEntries) {
+      updateStmt.run(entry.to, entry.file);
+    }
+  }
+
+  // Build summary
+  const summary = {
+    total: fileEntries.length,
+    primitive: fileEntries.filter((f) => f.to === "primitive").length,
+    composed: fileEntries.filter((f) => f.to === "composed").length,
+    layout: fileEntries.filter((f) => f.to === "layout").length,
+    changed: fileEntries.filter((f) => f.from !== f.to).length,
+  };
+
+  // Close database if we opened it
+  if (shouldCloseDb) {
+    db.close();
+  }
+
+  return {
+    kind: "classify",
+    applied: shouldApply,
+    files: fileEntries,
+    summary,
+  };
+}

--- a/packages/north/src/commands/find.test.ts
+++ b/packages/north/src/commands/find.test.ts
@@ -1,7 +1,12 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import type { IndexDatabase } from "../index/db.ts";
-import { TYPOGRAPHY_PREFIXES, buildCascade, buildTypographyUsage, parseTypographyUtility } from "./find.ts";
+import {
+  TYPOGRAPHY_PREFIXES,
+  buildCascade,
+  buildTypographyUsage,
+  parseTypographyUtility,
+} from "./find.ts";
 
 describe("parseTypographyUtility", () => {
   test("parses text size utilities", () => {
@@ -174,7 +179,6 @@ describe("buildTypographyUsage", () => {
     expect(result.values[2]).toEqual({ value: "sm", count: 1 });
   });
 });
-
 
 function createTestDb(): IndexDatabase {
   const db = new Database(":memory:");

--- a/packages/north/src/commands/find.ts
+++ b/packages/north/src/commands/find.ts
@@ -4,12 +4,7 @@ import { type IndexDatabase, openIndexDatabase } from "../index/db.ts";
 import { checkIndexFresh, getIndexStatus } from "../index/queries.ts";
 import { featureAvailable, getSchemaVersion } from "../index/version-guard.ts";
 import {
-  FONT_WEIGHT_VALUES,
-  LEADING_VALUES,
-  SPACING_PREFIXES,
-  TRACKING_VALUES,
   TYPOGRAPHY_PREFIXES as TYPOGRAPHY_PREFIXES_BASE,
-  TYPOGRAPHY_SIZE_VALUES,
   extractVarColorToken,
   isColorLiteralValue,
   parseColorUtility,
@@ -665,9 +660,10 @@ export function buildCascade(db: IndexDatabase, selector: string, limit: number)
 
   const limits: CascadeLimits = {
     confidence: missing.length === 0 && schemaLimitations.length === 0 ? "full" : "partial",
-    missing: missing.length > 0 || schemaLimitations.length > 0
-      ? [...missing, ...schemaLimitations]
-      : undefined,
+    missing:
+      missing.length > 0 || schemaLimitations.length > 0
+        ? [...missing, ...schemaLimitations]
+        : undefined,
   };
 
   return {

--- a/packages/north/src/mcp/server.ts
+++ b/packages/north/src/mcp/server.ts
@@ -7,9 +7,9 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { getGuidance, registerStatusTool } from "./tools/index.ts";
 import { registerContextTool } from "./tools/context.ts";
 import { registerDiscoverTool } from "./tools/discover.ts";
+import { getGuidance, registerStatusTool } from "./tools/index.ts";
 import { registerPromoteTool } from "./tools/promote.ts";
 import { registerRefactorTool } from "./tools/refactor.ts";
 import type { ServerState } from "./types.ts";


### PR DESCRIPTION
## Summary

Adds `north classify` CLI command that categorizes arbitrary values into design system domains.

## Changes

- Parse CSS values and classify into: colors, spacing, typography, shadows, borders, effects
- Support confidence scoring for ambiguous values
- Output structured JSON for programmatic use

## Test Plan

- [x] Typecheck passes
- [x] Lint passes
- [x] Command registered in CLI