### PR TITLE
feat(cli): add north migrate command

### DIFF
--- a/packages/north/src/commands/migrate.test.ts
+++ b/packages/north/src/commands/migrate.test.ts
@@ -1,0 +1,795 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MigrateError,
+  type MigrateOptions,
+  type MigrateReport,
+  type MigrationCheckpoint,
+  type StepResult,
+  applyExtract,
+  applyRemove,
+  applyReplace,
+  applyTokenize,
+} from "./migrate.ts";
+import type { MigrationAction, MigrationStep } from "./propose.ts";
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/**
+ * Create a mock migration step for testing
+ */
+function createMockStep(overrides: Partial<MigrationStep> = {}): MigrationStep {
+  return {
+    id: "step-001",
+    file: "src/components/Button.tsx",
+    line: 10,
+    column: 5,
+    ruleId: "north/no-raw-palette",
+    severity: "error",
+    action: { type: "replace", from: "bg-blue-500", to: "bg-(--primary)" },
+    confidence: 0.95,
+    preview: {
+      before: "bg-blue-500",
+      after: "bg-(--primary)",
+    },
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Error Type Tests
+// ============================================================================
+
+describe("MigrateError", () => {
+  test("creates error with message", () => {
+    const error = new MigrateError("test error");
+    expect(error.message).toBe("test error");
+    expect(error.name).toBe("MigrateError");
+  });
+
+  test("creates error with cause", () => {
+    const cause = new Error("root cause");
+    const error = new MigrateError("test error", cause);
+    expect(error.cause).toBe(cause);
+  });
+});
+
+// ============================================================================
+// MigrateOptions Type Tests
+// ============================================================================
+
+describe("MigrateOptions structure", () => {
+  test("options has all expected fields", () => {
+    const options: MigrateOptions = {
+      cwd: "/path/to/project",
+      config: "custom.config.yaml",
+      plan: ".north/migration-plan.json",
+      steps: ["step-001", "step-002"],
+      skip: ["step-003"],
+      file: "src/components/Button.tsx",
+      interactive: true,
+      backup: true,
+      dryRun: false,
+      apply: true,
+      continue: false,
+      json: false,
+      quiet: false,
+    };
+
+    expect(options.cwd).toBe("/path/to/project");
+    expect(options.steps).toEqual(["step-001", "step-002"]);
+    expect(options.interactive).toBe(true);
+  });
+
+  test("options defaults are reasonable", () => {
+    const options: MigrateOptions = {};
+    expect(options.cwd).toBeUndefined();
+    expect(options.backup).toBeUndefined(); // defaults to true
+    expect(options.dryRun).toBeUndefined(); // defaults to !apply
+  });
+});
+
+// ============================================================================
+// StepResult Type Tests
+// ============================================================================
+
+describe("StepResult structure", () => {
+  test("step result has required fields", () => {
+    const result: StepResult = {
+      stepId: "step-001",
+      status: "applied",
+      file: "src/components/Button.tsx",
+      action: "replace bg-blue-500 -> bg-(--primary)",
+    };
+
+    expect(result.stepId).toBe("step-001");
+    expect(result.status).toBe("applied");
+    expect(result.file).toBeDefined();
+    expect(result.action).toBeDefined();
+  });
+
+  test("step result can have optional error", () => {
+    const result: StepResult = {
+      stepId: "step-001",
+      status: "failed",
+      file: "src/components/Button.tsx",
+      action: "replace bg-blue-500 -> bg-(--primary)",
+      error: "Could not locate target at line 10",
+    };
+
+    expect(result.error).toBe("Could not locate target at line 10");
+  });
+
+  test("step result can have optional diff", () => {
+    const result: StepResult = {
+      stepId: "step-001",
+      status: "applied",
+      file: "src/components/Button.tsx",
+      action: "replace bg-blue-500 -> bg-(--primary)",
+      diff: { removed: 11, added: 14 },
+    };
+
+    expect(result.diff?.removed).toBe(11);
+    expect(result.diff?.added).toBe(14);
+  });
+
+  test("status values are valid", () => {
+    const statuses: StepResult["status"][] = ["applied", "skipped", "failed", "pending"];
+    for (const status of statuses) {
+      const result: StepResult = {
+        stepId: "step-001",
+        status,
+        file: "test.tsx",
+        action: "test action",
+      };
+      expect(result.status).toBe(status);
+    }
+  });
+});
+
+// ============================================================================
+// MigrationCheckpoint Type Tests
+// ============================================================================
+
+describe("MigrationCheckpoint structure", () => {
+  test("checkpoint has required fields", () => {
+    const checkpoint: MigrationCheckpoint = {
+      planPath: ".north/migration-plan.json",
+      planHash: "sha256:abc123def456",
+      completedSteps: ["step-001", "step-002"],
+      failedSteps: ["step-003"],
+      skippedSteps: [],
+      lastUpdated: new Date().toISOString(),
+    };
+
+    expect(checkpoint.planPath).toBe(".north/migration-plan.json");
+    expect(checkpoint.planHash).toMatch(/^sha256:/);
+    expect(checkpoint.completedSteps).toHaveLength(2);
+    expect(checkpoint.failedSteps).toHaveLength(1);
+    expect(checkpoint.lastUpdated).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+// ============================================================================
+// MigrateReport Type Tests
+// ============================================================================
+
+describe("MigrateReport structure", () => {
+  test("report has required fields", () => {
+    const report: MigrateReport = {
+      kind: "migrate",
+      applied: true,
+      planPath: ".north/migration-plan.json",
+      results: [],
+      summary: {
+        total: 10,
+        applied: 8,
+        skipped: 1,
+        failed: 1,
+        filesChanged: 5,
+        linesRemoved: 100,
+        linesAdded: 120,
+      },
+    };
+
+    expect(report.kind).toBe("migrate");
+    expect(report.applied).toBe(true);
+    expect(report.summary.total).toBe(10);
+  });
+
+  test("report can have optional checkpoint", () => {
+    const report: MigrateReport = {
+      kind: "migrate",
+      applied: true,
+      planPath: ".north/migration-plan.json",
+      results: [],
+      summary: {
+        total: 0,
+        applied: 0,
+        skipped: 0,
+        failed: 0,
+        filesChanged: 0,
+        linesRemoved: 0,
+        linesAdded: 0,
+      },
+      checkpoint: {
+        planPath: ".north/migration-plan.json",
+        planHash: "sha256:abc123",
+        completedSteps: [],
+        failedSteps: [],
+        skippedSteps: [],
+        lastUpdated: new Date().toISOString(),
+      },
+    };
+
+    expect(report.checkpoint).toBeDefined();
+    expect(report.checkpoint?.planHash).toMatch(/^sha256:/);
+  });
+
+  test("report can have optional nextSteps", () => {
+    const report: MigrateReport = {
+      kind: "migrate",
+      applied: true,
+      planPath: ".north/migration-plan.json",
+      results: [],
+      summary: {
+        total: 0,
+        applied: 0,
+        skipped: 0,
+        failed: 0,
+        filesChanged: 0,
+        linesRemoved: 0,
+        linesAdded: 0,
+      },
+      nextSteps: ["Fix failed steps", "Run 'north check'"],
+    };
+
+    expect(report.nextSteps).toHaveLength(2);
+    expect(report.nextSteps?.[0]).toBe("Fix failed steps");
+  });
+});
+
+// ============================================================================
+// applyReplace Tests
+// ============================================================================
+
+describe("applyReplace", () => {
+  test("replaces string at correct location", () => {
+    const content = `const Button = () => {
+  return <div className="bg-blue-500 text-white">Click me</div>;
+};`;
+
+    const result = applyReplace(content, 2, 24, "bg-blue-500", "bg-(--primary)");
+
+    expect(result).not.toBeNull();
+    expect(result?.content).toContain("bg-(--primary)");
+    expect(result?.content).not.toContain("bg-blue-500");
+    expect(result?.diff.removed).toBe(11);
+    expect(result?.diff.added).toBe(14);
+  });
+
+  test("returns null when line does not exist", () => {
+    const content = "single line";
+    const result = applyReplace(content, 5, 1, "foo", "bar");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when pattern not found", () => {
+    const content = `const x = "hello";`;
+    const result = applyReplace(content, 1, 1, "notfound", "replacement");
+    expect(result).toBeNull();
+  });
+
+  test("handles replacement when column is off by a few chars", () => {
+    const content = `className="bg-blue-500"`;
+    // Column might be slightly off due to parsing differences
+    const result = applyReplace(content, 1, 15, "bg-blue-500", "bg-(--primary)");
+    expect(result).not.toBeNull();
+    expect(result?.content).toContain("bg-(--primary)");
+  });
+
+  test("searches whole line when not found near column", () => {
+    const content = `className="bg-blue-500 text-white"`;
+    const result = applyReplace(content, 1, 100, "bg-blue-500", "bg-(--primary)");
+    expect(result).not.toBeNull();
+    expect(result?.content).toBe(`className="bg-(--primary) text-white"`);
+  });
+});
+
+// ============================================================================
+// applyExtract Tests
+// ============================================================================
+
+describe("applyExtract", () => {
+  test("extracts pattern and creates utility block", () => {
+    const content = `const Card = () => {
+  return <div className="flex items-center gap-2">Content</div>;
+};`;
+
+    const result = applyExtract(content, 2, "flex items-center gap-2", "card-layout");
+
+    expect(result).not.toBeNull();
+    expect(result?.content).toContain("card-layout");
+    expect(result?.content).not.toContain("flex items-center gap-2");
+    expect(result?.utilityBlock).toBe(
+      "@utility card-layout {\n  @apply flex items-center gap-2;\n}"
+    );
+  });
+
+  test("returns null when pattern not found", () => {
+    const content = `className="other-classes"`;
+    const result = applyExtract(content, 1, "notfound", "utility-name");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when line does not exist", () => {
+    const content = "single line";
+    const result = applyExtract(content, 5, "flex", "utility");
+    expect(result).toBeNull();
+  });
+
+  test("calculates diff correctly", () => {
+    const content = `className="flex items-center"`;
+    const result = applyExtract(content, 1, "flex items-center", "layout");
+
+    expect(result?.diff.removed).toBe("flex items-center".length);
+    expect(result?.diff.added).toBe("layout".length);
+  });
+});
+
+// ============================================================================
+// applyTokenize Tests
+// ============================================================================
+
+describe("applyTokenize", () => {
+  test("tokenizes arbitrary color value", () => {
+    const content = `const Button = () => {
+  return <div className="bg-[#ff0000] text-white">Click me</div>;
+};`;
+
+    const result = applyTokenize(content, 2, "bg-[#ff0000]", "--color-brand");
+
+    expect(result).not.toBeNull();
+    expect(result?.content).toContain("bg-(--color-brand)");
+    expect(result?.content).not.toContain("bg-[#ff0000]");
+    expect(result?.tokenDefinition).toBe("--color-brand: #ff0000;");
+  });
+
+  test("handles text color prefix", () => {
+    const content = `className="text-[#ffffff]"`;
+    const result = applyTokenize(content, 1, "text-[#ffffff]", "--color-light");
+
+    expect(result).not.toBeNull();
+    expect(result?.content).toContain("text-(--color-light)");
+    expect(result?.tokenDefinition).toBe("--color-light: #ffffff;");
+  });
+
+  test("handles border color prefix", () => {
+    const content = `className="border-[#000000]"`;
+    const result = applyTokenize(content, 1, "border-[#000000]", "--color-dark");
+
+    expect(result).not.toBeNull();
+    expect(result?.content).toContain("border-(--color-dark)");
+  });
+
+  test("returns null when value not found", () => {
+    const content = `className="bg-blue-500"`;
+    const result = applyTokenize(content, 1, "bg-[#ff0000]", "--color-custom");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when line does not exist", () => {
+    const content = "single line";
+    const result = applyTokenize(content, 5, "bg-[#ff0000]", "--color-custom");
+    expect(result).toBeNull();
+  });
+});
+
+// ============================================================================
+// applyRemove Tests
+// ============================================================================
+
+describe("applyRemove", () => {
+  test("removes class from className string", () => {
+    const content = `className="deprecated-class text-white"`;
+    const result = applyRemove(content, 1, 11, "deprecated-class");
+
+    expect(result).not.toBeNull();
+    expect(result?.content).toBe(`className="text-white"`);
+    expect(result?.diff.removed).toBeGreaterThan(0);
+    expect(result?.diff.added).toBe(0);
+  });
+
+  test("removes trailing space when present", () => {
+    const content = `className="remove-me keep-me"`;
+    const result = applyRemove(content, 1, 11, "remove-me");
+
+    expect(result?.content).toBe(`className="keep-me"`);
+  });
+
+  test("removes leading space when no trailing space", () => {
+    const content = `className="keep-me remove-me"`;
+    const result = applyRemove(content, 1, 19, "remove-me");
+
+    expect(result?.content).toBe(`className="keep-me"`);
+  });
+
+  test("returns null when class not found", () => {
+    const content = `className="text-white"`;
+    const result = applyRemove(content, 1, 1, "notfound");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when line does not exist", () => {
+    const content = "single line";
+    const result = applyRemove(content, 5, 1, "class");
+    expect(result).toBeNull();
+  });
+});
+
+// ============================================================================
+// Step Filtering Tests
+// ============================================================================
+
+describe("Step filtering logic", () => {
+  test("include filter keeps only specified steps", () => {
+    const steps = [
+      createMockStep({ id: "step-001" }),
+      createMockStep({ id: "step-002" }),
+      createMockStep({ id: "step-003" }),
+    ];
+
+    const includeSet = new Set(["step-001", "step-003"]);
+    const filtered = steps.filter((step) => includeSet.has(step.id));
+
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((s) => s.id)).toEqual(["step-001", "step-003"]);
+  });
+
+  test("skip filter excludes specified steps", () => {
+    const steps = [
+      createMockStep({ id: "step-001" }),
+      createMockStep({ id: "step-002" }),
+      createMockStep({ id: "step-003" }),
+    ];
+
+    const skipSet = new Set(["step-002"]);
+    const filtered = steps.filter((step) => !skipSet.has(step.id));
+
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((s) => s.id)).not.toContain("step-002");
+  });
+
+  test("file filter keeps only steps for specific file", () => {
+    const steps = [
+      createMockStep({ id: "step-001", file: "src/components/Button.tsx" }),
+      createMockStep({ id: "step-002", file: "src/components/Card.tsx" }),
+      createMockStep({ id: "step-003", file: "src/components/Button.tsx" }),
+    ];
+
+    const targetFile = "src/components/Button.tsx";
+    const filtered = steps.filter((step) => step.file === targetFile);
+
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((s) => s.id)).toEqual(["step-001", "step-003"]);
+  });
+
+  test("completed steps are excluded in continue mode", () => {
+    const steps = [
+      createMockStep({ id: "step-001" }),
+      createMockStep({ id: "step-002" }),
+      createMockStep({ id: "step-003" }),
+    ];
+
+    const completedSet = new Set(["step-001"]);
+    const filtered = steps.filter((step) => !completedSet.has(step.id));
+
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((s) => s.id)).not.toContain("step-001");
+  });
+});
+
+// ============================================================================
+// Topological Sort Tests
+// ============================================================================
+
+describe("Topological sort logic", () => {
+  test("steps without dependencies maintain order", () => {
+    const steps = [
+      createMockStep({ id: "step-001" }),
+      createMockStep({ id: "step-002" }),
+      createMockStep({ id: "step-003" }),
+    ];
+
+    // Simple sort maintains order when no dependencies
+    const sorted = [...steps].sort((a, b) => a.id.localeCompare(b.id));
+
+    expect(sorted.map((s) => s.id)).toEqual(["step-001", "step-002", "step-003"]);
+  });
+
+  test("dependencies are respected in sort order", () => {
+    // Step 002 depends on step 001
+    const steps = [
+      createMockStep({ id: "step-002", dependencies: ["step-001"] }),
+      createMockStep({ id: "step-001" }),
+    ];
+
+    // Simulating topological sort: dependencies come first
+    const sorted: MigrationStep[] = [];
+    const visited = new Set<string>();
+    const stepMap = new Map(steps.map((s) => [s.id, s]));
+
+    function visit(id: string) {
+      if (visited.has(id)) return;
+      const step = stepMap.get(id);
+      if (!step) return;
+
+      if (step.dependencies) {
+        for (const dep of step.dependencies) {
+          visit(dep);
+        }
+      }
+      visited.add(id);
+      sorted.push(step);
+    }
+
+    for (const step of steps) {
+      visit(step.id);
+    }
+
+    expect(sorted.map((s) => s.id)).toEqual(["step-001", "step-002"]);
+  });
+});
+
+// ============================================================================
+// Action Description Tests
+// ============================================================================
+
+describe("Action descriptions", () => {
+  test("replace action is described correctly", () => {
+    const action: MigrationAction = { type: "replace", from: "bg-blue-500", to: "bg-(--primary)" };
+    const description = `replace ${action.from} -> ${action.to}`;
+    expect(description).toBe("replace bg-blue-500 -> bg-(--primary)");
+  });
+
+  test("extract action is described correctly", () => {
+    const action: MigrationAction = {
+      type: "extract",
+      pattern: "flex items-center gap-2",
+      utilityName: "@apply-layout",
+    };
+    const description = `extract to ${action.utilityName}`;
+    expect(description).toBe("extract to @apply-layout");
+  });
+
+  test("tokenize action is described correctly", () => {
+    const action: MigrationAction = {
+      type: "tokenize",
+      value: "bg-[#ff0000]",
+      tokenName: "--color-brand",
+    };
+    const description = `tokenize ${action.value} as ${action.tokenName}`;
+    expect(description).toBe("tokenize bg-[#ff0000] as --color-brand");
+  });
+
+  test("remove action is described correctly", () => {
+    const action: MigrationAction = { type: "remove", className: "deprecated-class" };
+    const description = `remove ${action.className}`;
+    expect(description).toBe("remove deprecated-class");
+  });
+});
+
+// ============================================================================
+// Plan Hash Tests
+// ============================================================================
+
+describe("Plan hash integrity", () => {
+  test("same plan produces same hash", () => {
+    const plan = {
+      version: 1 as const,
+      createdAt: "2025-01-20T12:00:00Z",
+      strategy: "balanced" as const,
+      config: {},
+      steps: [],
+      summary: {
+        totalViolations: 0,
+        addressableViolations: 0,
+        filesAffected: 0,
+        byRule: {},
+        bySeverity: { error: 0, warn: 0, info: 0 },
+      },
+    };
+
+    const hash1 = `sha256:${require("node:crypto")
+      .createHash("sha256")
+      .update(JSON.stringify(plan))
+      .digest("hex")
+      .slice(0, 16)}`;
+    const hash2 = `sha256:${require("node:crypto")
+      .createHash("sha256")
+      .update(JSON.stringify(plan))
+      .digest("hex")
+      .slice(0, 16)}`;
+
+    expect(hash1).toBe(hash2);
+  });
+
+  test("different plans produce different hashes", () => {
+    const plan1 = { version: 1, steps: [] };
+    const plan2 = { version: 1, steps: [{ id: "step-001" }] };
+
+    const hash1 = require("node:crypto")
+      .createHash("sha256")
+      .update(JSON.stringify(plan1))
+      .digest("hex");
+    const hash2 = require("node:crypto")
+      .createHash("sha256")
+      .update(JSON.stringify(plan2))
+      .digest("hex");
+
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+// ============================================================================
+// Summary Calculation Tests
+// ============================================================================
+
+describe("Summary calculation", () => {
+  test("counts applied steps correctly", () => {
+    const results: StepResult[] = [
+      { stepId: "step-001", status: "applied", file: "a.tsx", action: "test" },
+      { stepId: "step-002", status: "applied", file: "b.tsx", action: "test" },
+      { stepId: "step-003", status: "failed", file: "c.tsx", action: "test" },
+      { stepId: "step-004", status: "skipped", file: "d.tsx", action: "test" },
+    ];
+
+    const applied = results.filter((r) => r.status === "applied").length;
+    const failed = results.filter((r) => r.status === "failed").length;
+    const skipped = results.filter((r) => r.status === "skipped").length;
+
+    expect(applied).toBe(2);
+    expect(failed).toBe(1);
+    expect(skipped).toBe(1);
+  });
+
+  test("counts unique files changed", () => {
+    const results: StepResult[] = [
+      { stepId: "step-001", status: "applied", file: "a.tsx", action: "test" },
+      { stepId: "step-002", status: "applied", file: "a.tsx", action: "test" },
+      { stepId: "step-003", status: "applied", file: "b.tsx", action: "test" },
+    ];
+
+    const filesChanged = new Set(results.filter((r) => r.status === "applied").map((r) => r.file))
+      .size;
+
+    expect(filesChanged).toBe(2);
+  });
+});
+
+// ============================================================================
+// Backup Strategy Tests
+// ============================================================================
+
+describe("Backup strategy", () => {
+  test("backup path is file.bak", () => {
+    const filePath = "src/components/Button.tsx";
+    const backupPath = `${filePath}.bak`;
+    expect(backupPath).toBe("src/components/Button.tsx.bak");
+  });
+
+  test("each file is backed up only once", () => {
+    const backedUp = new Set<string>();
+    const files = ["a.tsx", "a.tsx", "b.tsx", "a.tsx"];
+
+    for (const file of files) {
+      if (!backedUp.has(file)) {
+        backedUp.add(file);
+      }
+    }
+
+    expect(backedUp.size).toBe(2);
+    expect(backedUp.has("a.tsx")).toBe(true);
+    expect(backedUp.has("b.tsx")).toBe(true);
+  });
+});
+
+// ============================================================================
+// Interactive Mode Tests
+// ============================================================================
+
+describe("Interactive mode responses", () => {
+  test("normalizes yes responses", () => {
+    const responses = ["y", "Y", "yes", "YES", "Yes"];
+    for (const response of responses) {
+      const normalized = response.toLowerCase().trim();
+      expect(normalized === "y" || normalized === "yes").toBe(true);
+    }
+  });
+
+  test("normalizes no responses", () => {
+    const responses = ["n", "N", "no", "NO", "No"];
+    for (const response of responses) {
+      const normalized = response.toLowerCase().trim();
+      expect(normalized === "n" || normalized === "no").toBe(true);
+    }
+  });
+
+  test("normalizes quit responses", () => {
+    const responses = ["q", "Q", "quit", "QUIT"];
+    for (const response of responses) {
+      const normalized = response.toLowerCase().trim();
+      expect(normalized === "q" || normalized === "quit").toBe(true);
+    }
+  });
+
+  test("normalizes all responses", () => {
+    const responses = ["a", "A", "all", "ALL"];
+    for (const response of responses) {
+      const normalized = response.toLowerCase().trim();
+      expect(normalized === "a" || normalized === "all").toBe(true);
+    }
+  });
+});
+
+// ============================================================================
+// Next Steps Suggestions Tests
+// ============================================================================
+
+describe("Next steps suggestions", () => {
+  test("suggests fixing failures when steps fail", () => {
+    const failedCount = 2;
+    const nextSteps: string[] = [];
+
+    if (failedCount > 0) {
+      nextSteps.push("Fix failed steps manually or adjust plan");
+      nextSteps.push("Run 'north migrate --continue --apply' to retry");
+    }
+
+    expect(nextSteps).toHaveLength(2);
+    expect(nextSteps).toContain("Fix failed steps manually or adjust plan");
+  });
+
+  test("suggests running check after successful apply", () => {
+    const appliedCount = 5;
+    const nextSteps: string[] = [];
+
+    if (appliedCount > 0) {
+      nextSteps.push("Run 'north check' to verify remaining violations");
+    }
+
+    expect(nextSteps).toHaveLength(1);
+    expect(nextSteps[0]).toBe("Run 'north check' to verify remaining violations");
+  });
+});
+
+// ============================================================================
+// Dependency Skip Tests
+// ============================================================================
+
+describe("Dependency-based skipping", () => {
+  test("steps with failed dependencies are skipped", () => {
+    const failedSteps = ["step-001"];
+    const step = createMockStep({ id: "step-002", dependencies: ["step-001"] });
+
+    const hasFailedDep = step.dependencies?.some((depId) => failedSteps.includes(depId));
+    expect(hasFailedDep).toBe(true);
+  });
+
+  test("steps without dependencies are not skipped", () => {
+    const failedSteps = ["step-001"];
+    const step = createMockStep({ id: "step-002" });
+
+    const hasFailedDep = step.dependencies?.some((depId) => failedSteps.includes(depId)) ?? false;
+    expect(hasFailedDep).toBe(false);
+  });
+
+  test("steps with satisfied dependencies are not skipped", () => {
+    const failedSteps = ["step-003"];
+    const step = createMockStep({ id: "step-002", dependencies: ["step-001"] });
+
+    const hasFailedDep = step.dependencies?.some((depId) => failedSteps.includes(depId)) ?? false;
+    expect(hasFailedDep).toBe(false);
+  });
+});

--- a/packages/north/src/commands/migrate.ts
+++ b/packages/north/src/commands/migrate.ts
@@ -1,0 +1,1015 @@
+/**
+ * north migrate - Execute a migration plan in batch
+ *
+ * @see .scratch/mcp-server/15-cli-migrate-spec.md for full specification
+ */
+
+import { createHash } from "node:crypto";
+import { copyFile, mkdir, readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import * as readline from "node:readline";
+import chalk from "chalk";
+import { writeFileAtomic } from "../generation/file-writer.ts";
+import { buildIndex } from "../index/build.ts";
+import type { MigrationAction, MigrationPlan, MigrationStep } from "./propose.ts";
+
+// ============================================================================
+// Error Types
+// ============================================================================
+
+export class MigrateError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = "MigrateError";
+  }
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface MigrateOptions {
+  cwd?: string;
+  config?: string;
+  plan?: string;
+  steps?: string[];
+  skip?: string[];
+  file?: string;
+  interactive?: boolean;
+  backup?: boolean;
+  dryRun?: boolean;
+  apply?: boolean;
+  continue?: boolean;
+  json?: boolean;
+  quiet?: boolean;
+}
+
+export interface StepResult {
+  stepId: string;
+  status: "applied" | "skipped" | "failed" | "pending";
+  file: string;
+  action: string;
+  error?: string;
+  diff?: {
+    removed: number;
+    added: number;
+  };
+}
+
+export interface MigrationCheckpoint {
+  planPath: string;
+  planHash: string;
+  completedSteps: string[];
+  failedSteps: string[];
+  skippedSteps: string[];
+  lastUpdated: string;
+}
+
+export interface MigrateReport {
+  kind: "migrate";
+  applied: boolean;
+  planPath: string;
+  results: StepResult[];
+  summary: {
+    total: number;
+    applied: number;
+    skipped: number;
+    failed: number;
+    filesChanged: number;
+    linesRemoved: number;
+    linesAdded: number;
+  };
+  checkpoint?: MigrationCheckpoint;
+  nextSteps?: string[];
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_PLAN_PATH = ".north/migration-plan.json";
+const CHECKPOINT_PATH = ".north/migration-checkpoint.json";
+const BASE_CSS_FILE = "north/tokens/base.css";
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Compute SHA256 hash of plan for integrity checking
+ */
+function computePlanHash(plan: MigrationPlan): string {
+  const content = JSON.stringify(plan);
+  return `sha256:${createHash("sha256").update(content).digest("hex").slice(0, 16)}`;
+}
+
+/**
+ * Load migration plan from file
+ */
+async function loadPlan(planPath: string): Promise<MigrationPlan> {
+  try {
+    const content = await readFile(planPath, "utf-8");
+    const plan = JSON.parse(content) as MigrationPlan;
+
+    if (plan.version !== 1) {
+      throw new MigrateError(`Invalid plan format. Expected version 1, got ${plan.version}`);
+    }
+
+    return plan;
+  } catch (error) {
+    if (error instanceof MigrateError) {
+      throw error;
+    }
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      throw new MigrateError(`Plan not found: ${planPath}. Run 'north propose' first.`);
+    }
+    throw new MigrateError(
+      `Failed to load plan: ${error instanceof Error ? error.message : String(error)}`,
+      error
+    );
+  }
+}
+
+/**
+ * Load checkpoint file if it exists
+ */
+async function loadCheckpoint(checkpointPath: string): Promise<MigrationCheckpoint | null> {
+  try {
+    const content = await readFile(checkpointPath, "utf-8");
+    return JSON.parse(content) as MigrationCheckpoint;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save checkpoint to file
+ */
+async function saveCheckpoint(
+  checkpointPath: string,
+  checkpoint: MigrationCheckpoint
+): Promise<void> {
+  await mkdir(dirname(checkpointPath), { recursive: true });
+  await writeFileAtomic(checkpointPath, JSON.stringify(checkpoint, null, 2));
+}
+
+/**
+ * Filter steps based on options
+ */
+function filterSteps(
+  steps: MigrationStep[],
+  options: {
+    include?: string[];
+    skip?: string[];
+    file?: string;
+    completedSteps?: string[];
+  }
+): MigrationStep[] {
+  let filtered = steps;
+
+  // Filter by --steps (include only)
+  if (options.include && options.include.length > 0) {
+    const includeSet = new Set(options.include);
+    filtered = filtered.filter((step) => includeSet.has(step.id));
+  }
+
+  // Filter by --skip (exclude)
+  if (options.skip && options.skip.length > 0) {
+    const skipSet = new Set(options.skip);
+    filtered = filtered.filter((step) => !skipSet.has(step.id));
+  }
+
+  // Filter by --file
+  if (options.file) {
+    const targetFile = options.file;
+    filtered = filtered.filter(
+      (step) => step.file === targetFile || step.file.endsWith(`/${targetFile}`)
+    );
+  }
+
+  // Filter out completed steps (for --continue)
+  if (options.completedSteps && options.completedSteps.length > 0) {
+    const completedSet = new Set(options.completedSteps);
+    filtered = filtered.filter((step) => !completedSet.has(step.id));
+  }
+
+  return filtered;
+}
+
+/**
+ * Topological sort steps by dependencies
+ * Steps with no dependencies come first
+ */
+function topologicalSort(steps: MigrationStep[]): MigrationStep[] {
+  const stepMap = new Map(steps.map((s) => [s.id, s]));
+  const sorted: MigrationStep[] = [];
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+
+  function visit(stepId: string): void {
+    if (visited.has(stepId)) return;
+    if (visiting.has(stepId)) {
+      // Circular dependency - skip it
+      return;
+    }
+
+    visiting.add(stepId);
+    const step = stepMap.get(stepId);
+    if (step) {
+      // Visit dependencies first
+      if (step.dependencies) {
+        for (const depId of step.dependencies) {
+          if (stepMap.has(depId)) {
+            visit(depId);
+          }
+        }
+      }
+      visited.add(stepId);
+      sorted.push(step);
+    }
+    visiting.delete(stepId);
+  }
+
+  for (const step of steps) {
+    visit(step.id);
+  }
+
+  return sorted;
+}
+
+/**
+ * Describe an action in human-readable form
+ */
+function describeAction(action: MigrationAction): string {
+  switch (action.type) {
+    case "replace":
+      return `replace ${action.from} -> ${action.to}`;
+    case "extract":
+      return `extract to ${action.utilityName}`;
+    case "tokenize":
+      return `tokenize ${action.value} as ${action.tokenName}`;
+    case "remove":
+      return `remove ${action.className}`;
+  }
+}
+
+// ============================================================================
+// Transformation Functions
+// ============================================================================
+
+/**
+ * Apply replace transformation: string substitution at location
+ */
+export function applyReplace(
+  content: string,
+  line: number,
+  column: number,
+  from: string,
+  to: string
+): { content: string; diff: { removed: number; added: number } } | null {
+  const lines = content.split("\n");
+  const targetLine = lines[line - 1];
+
+  if (!targetLine) {
+    return null;
+  }
+
+  // Find the 'from' string starting near the column position
+  // Search within a reasonable range around the column
+  const searchStart = Math.max(0, column - 5);
+  const searchEnd = Math.min(targetLine.length, column + from.length + 50);
+  const searchArea = targetLine.slice(searchStart, searchEnd);
+
+  const idx = searchArea.indexOf(from);
+  if (idx === -1) {
+    // Try searching the whole line
+    const fullIdx = targetLine.indexOf(from);
+    if (fullIdx === -1) {
+      return null;
+    }
+    lines[line - 1] = targetLine.slice(0, fullIdx) + to + targetLine.slice(fullIdx + from.length);
+  } else {
+    const actualIdx = searchStart + idx;
+    lines[line - 1] =
+      targetLine.slice(0, actualIdx) + to + targetLine.slice(actualIdx + from.length);
+  }
+
+  return {
+    content: lines.join("\n"),
+    diff: {
+      removed: from.length,
+      added: to.length,
+    },
+  };
+}
+
+/**
+ * Apply extract transformation: add @utility to base.css + update file
+ */
+export function applyExtract(
+  content: string,
+  line: number,
+  pattern: string,
+  utilityName: string
+): { content: string; utilityBlock: string; diff: { removed: number; added: number } } | null {
+  const lines = content.split("\n");
+  const targetLine = lines[line - 1];
+
+  if (!targetLine) {
+    return null;
+  }
+
+  // Find the pattern in the line
+  const idx = targetLine.indexOf(pattern);
+  if (idx === -1) {
+    return null;
+  }
+
+  // Replace pattern with utility name
+  lines[line - 1] = targetLine.slice(0, idx) + utilityName + targetLine.slice(idx + pattern.length);
+
+  // Generate utility block
+  const utilityBlock = `@utility ${utilityName} {\n  @apply ${pattern};\n}`;
+
+  return {
+    content: lines.join("\n"),
+    utilityBlock,
+    diff: {
+      removed: pattern.length,
+      added: utilityName.length,
+    },
+  };
+}
+
+/**
+ * Apply tokenize transformation: conceptually add token + update file
+ * Note: The actual token definition needs to be added to tokens file separately
+ */
+export function applyTokenize(
+  content: string,
+  line: number,
+  value: string,
+  tokenName: string
+): { content: string; tokenDefinition: string; diff: { removed: number; added: number } } | null {
+  const lines = content.split("\n");
+  const targetLine = lines[line - 1];
+
+  if (!targetLine) {
+    return null;
+  }
+
+  // Find the value in the line
+  const idx = targetLine.indexOf(value);
+  if (idx === -1) {
+    return null;
+  }
+
+  // Generate replacement (use CSS var reference for the token)
+  // Extract the property prefix (bg, text, border, etc.) from the value
+  const prefixMatch = value.match(/^(bg|text|border|ring|fill|stroke)-/);
+  const prefix = prefixMatch ? prefixMatch[1] : "bg";
+  const tokenRef = `${prefix}-(${tokenName})`;
+
+  // Replace value with token reference
+  lines[line - 1] = targetLine.slice(0, idx) + tokenRef + targetLine.slice(idx + value.length);
+
+  // Generate token definition (to be added to tokens file)
+  // Extract the actual color value from arbitrary syntax like bg-[#ff0000]
+  const colorMatch = value.match(/\[([^\]]+)\]/);
+  const colorValue = colorMatch ? colorMatch[1] : value;
+  const tokenDefinition = `${tokenName}: ${colorValue};`;
+
+  return {
+    content: lines.join("\n"),
+    tokenDefinition,
+    diff: {
+      removed: value.length,
+      added: tokenRef.length,
+    },
+  };
+}
+
+/**
+ * Apply remove transformation: delete class from className string
+ */
+export function applyRemove(
+  content: string,
+  line: number,
+  _column: number,
+  className: string
+): { content: string; diff: { removed: number; added: number } } | null {
+  const lines = content.split("\n");
+  const targetLine = lines[line - 1];
+
+  if (!targetLine) {
+    return null;
+  }
+
+  // Find the className in the line
+  const idx = targetLine.indexOf(className);
+  if (idx === -1) {
+    return null;
+  }
+
+  // Remove the class and any surrounding whitespace
+  let removeStart = idx;
+  let removeEnd = idx + className.length;
+
+  // Remove trailing space if present
+  if (targetLine[removeEnd] === " ") {
+    removeEnd += 1;
+  } else if (removeStart > 0 && targetLine[removeStart - 1] === " ") {
+    // Or leading space if no trailing space
+    removeStart -= 1;
+  }
+
+  lines[line - 1] = targetLine.slice(0, removeStart) + targetLine.slice(removeEnd);
+
+  return {
+    content: lines.join("\n"),
+    diff: {
+      removed: removeEnd - removeStart,
+      added: 0,
+    },
+  };
+}
+
+/**
+ * Apply a migration step to file content
+ */
+function applyStep(
+  content: string,
+  step: MigrationStep
+): {
+  content: string;
+  sideEffect?: { type: "utility" | "token"; value: string };
+  diff: { removed: number; added: number };
+} | null {
+  const { action, line, column } = step;
+
+  switch (action.type) {
+    case "replace": {
+      const result = applyReplace(content, line, column, action.from, action.to);
+      if (!result) return null;
+      return { content: result.content, diff: result.diff };
+    }
+
+    case "extract": {
+      const result = applyExtract(content, line, action.pattern, action.utilityName);
+      if (!result) return null;
+      return {
+        content: result.content,
+        sideEffect: { type: "utility", value: result.utilityBlock },
+        diff: result.diff,
+      };
+    }
+
+    case "tokenize": {
+      const result = applyTokenize(content, line, action.value, action.tokenName);
+      if (!result) return null;
+      return {
+        content: result.content,
+        sideEffect: { type: "token", value: result.tokenDefinition },
+        diff: result.diff,
+      };
+    }
+
+    case "remove": {
+      const result = applyRemove(content, line, column, action.className);
+      if (!result) return null;
+      return { content: result.content, diff: result.diff };
+    }
+  }
+}
+
+// ============================================================================
+// Interactive Mode
+// ============================================================================
+
+/**
+ * Prompt user for confirmation in interactive mode
+ */
+async function promptUser(
+  step: MigrationStep,
+  rl: readline.Interface
+): Promise<"yes" | "no" | "quit" | "all"> {
+  const action = describeAction(step.action);
+
+  console.log("");
+  console.log(chalk.bold(`Step ${step.id}: ${action}`));
+  console.log(`File: ${step.file}:${step.line}`);
+  console.log("");
+  console.log(chalk.dim("Before:"));
+  console.log(`  ${step.preview.before}`);
+  console.log("");
+  console.log(chalk.dim("After:"));
+  console.log(`  ${step.preview.after}`);
+  console.log("");
+
+  return new Promise((resolve) => {
+    rl.question("Apply this change? [y]es / [n]o / [q]uit / [a]ll remaining: ", (answer) => {
+      const normalized = answer.toLowerCase().trim();
+      if (normalized === "y" || normalized === "yes") {
+        resolve("yes");
+      } else if (normalized === "n" || normalized === "no") {
+        resolve("no");
+      } else if (normalized === "q" || normalized === "quit") {
+        resolve("quit");
+      } else if (normalized === "a" || normalized === "all") {
+        resolve("all");
+      } else {
+        // Default to no
+        resolve("no");
+      }
+    });
+  });
+}
+
+// ============================================================================
+// Output Formatting
+// ============================================================================
+
+/**
+ * Format step result symbol
+ */
+function formatResultSymbol(status: StepResult["status"]): string {
+  switch (status) {
+    case "applied":
+      return chalk.green("ok");
+    case "skipped":
+      return chalk.yellow("skip");
+    case "failed":
+      return chalk.red("FAIL");
+    case "pending":
+      return chalk.dim("...");
+  }
+}
+
+/**
+ * Format dry-run output
+ */
+function formatDryRunOutput(plan: MigrationPlan, steps: MigrationStep[], planPath: string): string {
+  const lines: string[] = [];
+
+  lines.push(chalk.bold("Migration Preview (dry-run)"));
+  lines.push("");
+  lines.push(`Plan: ${planPath}`);
+  lines.push(`Steps: ${plan.steps.length} total, ${steps.length} will execute`);
+  lines.push("");
+
+  // Show first few steps
+  const previewLimit = 10;
+  for (const step of steps.slice(0, previewLimit)) {
+    const action = describeAction(step.action);
+    lines.push(`Step ${step.id} ${chalk.dim("[PREVIEW]")}`);
+    lines.push(`  File: ${step.file}:${step.line}`);
+    lines.push(`  Rule: ${step.ruleId.replace("north/", "")}`);
+    lines.push(`  Action: ${action}`);
+    lines.push("");
+  }
+
+  if (steps.length > previewLimit) {
+    lines.push(chalk.dim(`... (${steps.length - previewLimit} more steps)`));
+    lines.push("");
+  }
+
+  // Estimate changes
+  const filesAffected = new Set(steps.map((s) => s.file)).size;
+
+  lines.push(chalk.bold("Summary:"));
+  lines.push(`  Steps: ${steps.length}`);
+  lines.push(`  Files: ${filesAffected}`);
+  lines.push("");
+  lines.push("Run 'north migrate --apply' to execute.");
+
+  return lines.join("\n");
+}
+
+/**
+ * Format applied output
+ */
+function formatAppliedOutput(report: MigrateReport, showAllResults = false): string {
+  const lines: string[] = [];
+
+  lines.push(chalk.bold("Migration Applied"));
+  lines.push("");
+  lines.push(`Plan: ${report.planPath}`);
+  lines.push("");
+  lines.push(chalk.bold("Results:"));
+
+  // Show results (limited or all)
+  const resultsToShow = showAllResults ? report.results : report.results.slice(0, 20);
+  for (const result of resultsToShow) {
+    const symbol = formatResultSymbol(result.status);
+    const fileName = result.file.split("/").pop() ?? result.file;
+    lines.push(`  ${symbol} ${result.stepId}: ${fileName} - ${result.action}`);
+  }
+
+  if (!showAllResults && report.results.length > 20) {
+    lines.push(chalk.dim(`  ... (${report.results.length - 20} more results)`));
+  }
+
+  lines.push("");
+  lines.push(chalk.bold("Summary:"));
+  lines.push(`  Total: ${report.summary.total}`);
+  lines.push(`  Applied: ${chalk.green(String(report.summary.applied))}`);
+  lines.push(
+    `  Failed: ${report.summary.failed > 0 ? chalk.red(String(report.summary.failed)) : "0"}`
+  );
+  lines.push(
+    `  Skipped: ${report.summary.skipped > 0 ? chalk.yellow(String(report.summary.skipped)) : "0"}`
+  );
+  lines.push(`  Files changed: ${report.summary.filesChanged}`);
+  lines.push(
+    `  Lines: ${chalk.red(`-${report.summary.linesRemoved}`)}, ${chalk.green(`+${report.summary.linesAdded}`)}`
+  );
+
+  if (report.checkpoint) {
+    lines.push("");
+    lines.push(chalk.dim(`Checkpoint saved: ${CHECKPOINT_PATH}`));
+  }
+
+  if (report.nextSteps && report.nextSteps.length > 0) {
+    lines.push("");
+    lines.push(chalk.bold("Next steps:"));
+    for (let i = 0; i < report.nextSteps.length; i++) {
+      lines.push(`  ${i + 1}. ${report.nextSteps[i]}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// ============================================================================
+// Main Command
+// ============================================================================
+
+export async function migrate(options: MigrateOptions = {}): Promise<MigrateReport> {
+  const cwd = options.cwd ?? process.cwd();
+  const planPath = options.plan ? resolve(cwd, options.plan) : resolve(cwd, DEFAULT_PLAN_PATH);
+  const checkpointPath = resolve(cwd, CHECKPOINT_PATH);
+  const apply = options.apply === true;
+  const dryRun = options.dryRun ?? !apply;
+  const backup = options.backup !== false;
+  const interactive = options.interactive === true;
+  const continueFromCheckpoint = options.continue === true;
+
+  // 1. Load and validate plan
+  const plan = await loadPlan(planPath);
+  const planHash = computePlanHash(plan);
+
+  // 2. Load checkpoint if --continue
+  let checkpoint: MigrationCheckpoint | null = null;
+  if (continueFromCheckpoint) {
+    checkpoint = await loadCheckpoint(checkpointPath);
+    if (checkpoint) {
+      if (checkpoint.planHash !== planHash) {
+        throw new MigrateError("Plan has changed since checkpoint. Remove checkpoint to restart.");
+      }
+    }
+  }
+
+  // 3. Filter steps
+  const filteredSteps = filterSteps(plan.steps, {
+    include: options.steps,
+    skip: options.skip,
+    file: options.file,
+    completedSteps: checkpoint?.completedSteps,
+  });
+
+  // 4. Topological sort by dependencies
+  const sortedSteps = topologicalSort(filteredSteps);
+
+  // Handle no steps case
+  if (sortedSteps.length === 0) {
+    const emptyReport: MigrateReport = {
+      kind: "migrate",
+      applied: false,
+      planPath,
+      results: [],
+      summary: {
+        total: 0,
+        applied: 0,
+        skipped: 0,
+        failed: 0,
+        filesChanged: 0,
+        linesRemoved: 0,
+        linesAdded: 0,
+      },
+      nextSteps: checkpoint
+        ? ["All steps completed or skipped."]
+        : ["No steps to execute. Check filters or run 'north propose' to generate a new plan."],
+    };
+
+    if (!options.quiet) {
+      if (options.json) {
+        console.log(JSON.stringify(emptyReport, null, 2));
+      } else {
+        console.log("No steps to execute.");
+      }
+    }
+
+    return emptyReport;
+  }
+
+  // For dry-run, just preview
+  if (dryRun) {
+    const results: StepResult[] = sortedSteps.map((step) => ({
+      stepId: step.id,
+      status: "pending" as const,
+      file: step.file,
+      action: describeAction(step.action),
+    }));
+
+    const filesAffected = new Set(sortedSteps.map((s) => s.file)).size;
+
+    const report: MigrateReport = {
+      kind: "migrate",
+      applied: false,
+      planPath,
+      results,
+      summary: {
+        total: sortedSteps.length,
+        applied: 0,
+        skipped: 0,
+        failed: 0,
+        filesChanged: filesAffected,
+        linesRemoved: 0,
+        linesAdded: 0,
+      },
+    };
+
+    if (!options.quiet) {
+      if (options.json) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        console.log(formatDryRunOutput(plan, sortedSteps, planPath));
+      }
+    }
+
+    return report;
+  }
+
+  // 5. Execute steps
+  const results: StepResult[] = [];
+  const completedSteps: string[] = checkpoint?.completedSteps ?? [];
+  const failedSteps: string[] = checkpoint?.failedSteps ?? [];
+  const skippedSteps: string[] = checkpoint?.skippedSteps ?? [];
+  const fileContents = new Map<string, string>();
+  const backedUpFiles = new Set<string>();
+  const utilityBlocks: string[] = [];
+  const tokenDefinitions: string[] = [];
+  let totalRemoved = 0;
+  let totalAdded = 0;
+  let applyAll = false;
+
+  // Set up readline for interactive mode
+  let rl: readline.Interface | null = null;
+  if (interactive) {
+    rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+  }
+
+  try {
+    for (const step of sortedSteps) {
+      const filePath = resolve(cwd, step.file);
+
+      // Check if dependencies failed
+      if (step.dependencies) {
+        const hasFailedDep = step.dependencies.some((depId) => failedSteps.includes(depId));
+        if (hasFailedDep) {
+          results.push({
+            stepId: step.id,
+            status: "skipped",
+            file: step.file,
+            action: describeAction(step.action),
+            error: "Dependency failed",
+          });
+          skippedSteps.push(step.id);
+          continue;
+        }
+      }
+
+      // Interactive mode prompt
+      if (interactive && !applyAll && rl) {
+        const response = await promptUser(step, rl);
+        if (response === "quit") {
+          // Save checkpoint and exit
+          break;
+        }
+        if (response === "no") {
+          results.push({
+            stepId: step.id,
+            status: "skipped",
+            file: step.file,
+            action: describeAction(step.action),
+          });
+          skippedSteps.push(step.id);
+          continue;
+        }
+        if (response === "all") {
+          applyAll = true;
+        }
+      }
+
+      // Load file content (cached)
+      let content = fileContents.get(filePath);
+      if (content === undefined) {
+        try {
+          content = await readFile(filePath, "utf-8");
+          fileContents.set(filePath, content);
+        } catch (_error) {
+          results.push({
+            stepId: step.id,
+            status: "failed",
+            file: step.file,
+            action: describeAction(step.action),
+            error: `File not found: ${step.file}`,
+          });
+          failedSteps.push(step.id);
+          continue;
+        }
+      }
+
+      // Apply transformation
+      const transformResult = applyStep(content, step);
+
+      if (!transformResult) {
+        results.push({
+          stepId: step.id,
+          status: "failed",
+          file: step.file,
+          action: describeAction(step.action),
+          error: `Could not locate target at line ${step.line}`,
+        });
+        failedSteps.push(step.id);
+        continue;
+      }
+
+      // Create backup if first change to file
+      if (backup && !backedUpFiles.has(filePath)) {
+        try {
+          await copyFile(filePath, `${filePath}.bak`);
+          backedUpFiles.add(filePath);
+        } catch {
+          // Backup failed, but continue anyway
+        }
+      }
+
+      // Update cached content
+      fileContents.set(filePath, transformResult.content);
+
+      // Collect side effects
+      if (transformResult.sideEffect) {
+        if (transformResult.sideEffect.type === "utility") {
+          utilityBlocks.push(transformResult.sideEffect.value);
+        } else if (transformResult.sideEffect.type === "token") {
+          tokenDefinitions.push(transformResult.sideEffect.value);
+        }
+      }
+
+      totalRemoved += transformResult.diff.removed;
+      totalAdded += transformResult.diff.added;
+
+      results.push({
+        stepId: step.id,
+        status: "applied",
+        file: step.file,
+        action: describeAction(step.action),
+        diff: transformResult.diff,
+      });
+      completedSteps.push(step.id);
+    }
+  } finally {
+    if (rl) {
+      rl.close();
+    }
+  }
+
+  // 6. Write modified files
+  const modifiedFiles = new Set<string>();
+  for (const [filePath, content] of fileContents) {
+    try {
+      // Read original to check if changed
+      const original = await readFile(filePath, "utf-8").catch(() => null);
+      if (original !== content) {
+        await writeFileAtomic(filePath, content);
+        modifiedFiles.add(filePath);
+      }
+    } catch (error) {
+      // Mark affected steps as failed
+      for (const result of results) {
+        if (resolve(cwd, result.file) === filePath && result.status === "applied") {
+          result.status = "failed";
+          result.error = `Failed to write file: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      }
+    }
+  }
+
+  // 7. Append utilities and tokens to base.css
+  if (utilityBlocks.length > 0 || tokenDefinitions.length > 0) {
+    const baseCssPath = resolve(cwd, BASE_CSS_FILE);
+    try {
+      let baseCss = await readFile(baseCssPath, "utf-8").catch(() => "");
+
+      if (tokenDefinitions.length > 0) {
+        const tokenBlock = `\n/* north migrate: tokens */\n@theme {\n  ${tokenDefinitions.join("\n  ")}\n}\n`;
+        baseCss = baseCss.trimEnd() + tokenBlock;
+      }
+
+      if (utilityBlocks.length > 0) {
+        const utilitySection = `\n/* north migrate: utilities */\n${utilityBlocks.join("\n\n")}\n`;
+        baseCss = baseCss.trimEnd() + utilitySection;
+      }
+
+      await writeFileAtomic(baseCssPath, baseCss);
+      modifiedFiles.add(baseCssPath);
+    } catch (error) {
+      // Non-fatal: log but continue
+      if (!options.quiet && !options.json) {
+        console.log(
+          chalk.yellow(
+            `Warning: Could not update ${BASE_CSS_FILE}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        );
+      }
+    }
+  }
+
+  // 8. Rebuild index if files changed
+  if (modifiedFiles.size > 0) {
+    try {
+      await buildIndex({ cwd, configPath: options.config });
+    } catch {
+      // Non-fatal: index rebuild failed
+    }
+  }
+
+  // 9. Save checkpoint
+  const newCheckpoint: MigrationCheckpoint = {
+    planPath,
+    planHash,
+    completedSteps,
+    failedSteps,
+    skippedSteps,
+    lastUpdated: new Date().toISOString(),
+  };
+
+  await saveCheckpoint(checkpointPath, newCheckpoint);
+
+  // 10. Build report
+  const appliedCount = results.filter((r) => r.status === "applied").length;
+  const failedCount = results.filter((r) => r.status === "failed").length;
+  const skippedCount = results.filter((r) => r.status === "skipped").length;
+
+  const nextSteps: string[] = [];
+  if (failedCount > 0) {
+    nextSteps.push("Fix failed steps manually or adjust plan");
+    nextSteps.push("Run 'north migrate --continue --apply' to retry");
+  }
+  if (appliedCount > 0) {
+    nextSteps.push("Run 'north check' to verify remaining violations");
+  }
+
+  const report: MigrateReport = {
+    kind: "migrate",
+    applied: true,
+    planPath,
+    results,
+    summary: {
+      total: results.length,
+      applied: appliedCount,
+      skipped: skippedCount,
+      failed: failedCount,
+      filesChanged: modifiedFiles.size,
+      linesRemoved: totalRemoved,
+      linesAdded: totalAdded,
+    },
+    checkpoint: newCheckpoint,
+    nextSteps: nextSteps.length > 0 ? nextSteps : undefined,
+  };
+
+  // 11. Output
+  if (!options.quiet) {
+    if (options.json) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      console.log(formatAppliedOutput(report));
+    }
+  }
+
+  return report;
+}
+
+// Re-export MigrationPlan for convenience
+export type { MigrationPlan };


### PR DESCRIPTION
## Summary

Adds `north migrate` CLI command that executes migration plans safely.

## Changes

- Parse migration plan JSON from `north propose`
- Execute steps with dry-run by default
- Support backup creation before changes
- Checkpoint progress for resumable migrations
- Filter by specific steps or files

## Test Plan

- [x] Typecheck passes
- [x] Lint passes
- [x] Dry-run mode prevents actual changes