### PR TITLE
feat(mcp): implement north_suggest tool

### DIFF
--- a/packages/north/src/config/schema.ts
+++ b/packages/north/src/config/schema.ts
@@ -75,7 +75,7 @@ export const OKLCHColorSchema = z
 
 export type OKLCHColor = z.infer<typeof OKLCHColorSchema>;
 
-// shadcn color mapping
+// shadcn color mapping with support for custom semantic tokens
 export const ColorsConfigSchema = z
   .object({
     background: OKLCHColorSchema.optional(),
@@ -98,6 +98,8 @@ export const ColorsConfigSchema = z
     input: OKLCHColorSchema.optional(),
     ring: OKLCHColorSchema.optional(),
   })
+  // Allow custom semantic tokens (e.g., success, warning) beyond the standard shadcn set
+  .catchall(OKLCHColorSchema)
   .optional();
 
 export type ColorsConfig = z.infer<typeof ColorsConfigSchema>;

--- a/packages/north/src/mcp/server.ts
+++ b/packages/north/src/mcp/server.ts
@@ -14,6 +14,7 @@ import { getGuidance, registerStatusTool } from "./tools/index.ts";
 import { registerPromoteTool } from "./tools/promote.ts";
 import { registerQueryTool } from "./tools/query.ts";
 import { registerRefactorTool } from "./tools/refactor.ts";
+import { registerSuggestTool } from "./tools/suggest.ts";
 import type { ServerState } from "./types.ts";
 
 // Re-export getGuidance for backward compatibility with tests
@@ -161,6 +162,7 @@ function registerTools(server: McpServer): void {
   // Tier 2: Config-dependent tools
   registerContextTool(server);
   registerCheckTool(server);
+  registerSuggestTool(server);
 
   // Tier 3: Index-dependent tools
   registerDiscoverTool(server);

--- a/packages/north/src/mcp/tools/index.ts
+++ b/packages/north/src/mcp/tools/index.ts
@@ -28,6 +28,17 @@ export {
 // Context tool (Tier 2)
 export { registerContextTool, executeContextTool, type ContextPayload } from "./context.ts";
 
+// Suggest tool (Tier 2)
+export {
+  type SuggestInput,
+  SuggestInputSchema,
+  type SuggestOptions,
+  type SuggestResponse,
+  type TokenSuggestion,
+  executeSuggestTool,
+  registerSuggestTool,
+} from "./suggest.ts";
+
 // Discover tool (Tier 3)
 export {
   type DiscoverInput,

--- a/packages/north/src/mcp/tools/suggest.test.ts
+++ b/packages/north/src/mcp/tools/suggest.test.ts
@@ -1,0 +1,425 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { type SuggestResponse, executeSuggestTool } from "./suggest.ts";
+
+describe("executeSuggestTool", () => {
+  const testDir = resolve(import.meta.dir, ".test-fixtures-suggest-tool");
+
+  beforeEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function setupTestConfig(config: string): Promise<string> {
+    const northDir = resolve(testDir, "north");
+    const rulesDir = resolve(northDir, "rules");
+    await mkdir(rulesDir, { recursive: true });
+    const configPath = resolve(northDir, "north.config.yaml");
+    await writeFile(configPath, config);
+
+    // Create a placeholder rule
+    await writeFile(
+      resolve(rulesDir, "placeholder.yaml"),
+      `id: north/placeholder
+language: tsx
+severity: "off"
+message: "Placeholder"
+rule:
+  kind: string_fragment
+  regex: "^$"
+`
+    );
+
+    return configPath;
+  }
+
+  test("suggests semantic color replacement for raw palette class", async () => {
+    const configPath = await setupTestConfig(`compatibility:
+  tailwind: "4"
+`);
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    const filePath = resolve(srcDir, "Button.tsx");
+    await writeFile(
+      filePath,
+      `export function Button() {
+  return <button className="bg-blue-500 text-white">Click me</button>;
+}
+`
+    );
+
+    const payload = await executeSuggestTool(testDir, configPath, {
+      file: filePath,
+      category: "colors",
+    });
+
+    expect(payload.kind).toBe("suggest");
+    expect(payload.file).toBe(filePath);
+    expect(payload.suggestions.length).toBeGreaterThan(0);
+
+    const colorSuggestion = payload.suggestions.find((s) => s.current.includes("bg-blue-500"));
+    expect(colorSuggestion).toBeDefined();
+    expect(colorSuggestion?.category).toBe("color");
+    expect(colorSuggestion?.suggested).toContain("primary");
+  });
+
+  test("suggests semantic spacing replacement for numeric spacing", async () => {
+    const configPath = await setupTestConfig(`compatibility:
+  tailwind: "4"
+`);
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    const filePath = resolve(srcDir, "Card.tsx");
+    await writeFile(
+      filePath,
+      `export function Card() {
+  return <div className="p-4 m-2 gap-6">Content</div>;
+}
+`
+    );
+
+    const payload = await executeSuggestTool(testDir, configPath, {
+      file: filePath,
+      category: "spacing",
+    });
+
+    expect(payload.kind).toBe("suggest");
+    expect(payload.suggestions.length).toBeGreaterThan(0);
+
+    // Should suggest semantic spacing for p-4, m-2, gap-6
+    const spacingSuggestions = payload.suggestions.filter((s) => s.category === "spacing");
+    expect(spacingSuggestions.length).toBeGreaterThan(0);
+  });
+
+  test("filters by line number when provided", async () => {
+    const configPath = await setupTestConfig(`compatibility:
+  tailwind: "4"
+`);
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    const filePath = resolve(srcDir, "Widget.tsx");
+    await writeFile(
+      filePath,
+      `export function Widget() {
+  return (
+    <div className="bg-red-500">
+      <span className="bg-green-500">Line 4</span>
+    </div>
+  );
+}
+`
+    );
+
+    const payload = await executeSuggestTool(testDir, configPath, {
+      file: filePath,
+      line: 4, // Line with bg-green-500
+      category: "colors",
+    });
+
+    expect(payload.kind).toBe("suggest");
+    expect(payload.line).toBe(4);
+    // Should focus on line 4's classes
+    const greenSuggestion = payload.suggestions.find((s) => s.current.includes("bg-green-500"));
+    expect(greenSuggestion).toBeDefined();
+  });
+
+  test("suggests fix for specific violation when provided", async () => {
+    const configPath = await setupTestConfig(`compatibility:
+  tailwind: "4"
+`);
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    const filePath = resolve(srcDir, "Alert.tsx");
+    await writeFile(
+      filePath,
+      `export function Alert() {
+  return <div className="bg-red-500 text-red-100">Alert!</div>;
+}
+`
+    );
+
+    const payload = await executeSuggestTool(testDir, configPath, {
+      file: filePath,
+      violation: "bg-red-500",
+      category: "colors",
+    });
+
+    expect(payload.kind).toBe("suggest");
+    const redSuggestion = payload.suggestions.find((s) => s.current === "bg-red-500");
+    expect(redSuggestion).toBeDefined();
+    expect(redSuggestion?.suggested).toContain("destructive");
+    expect(redSuggestion?.confidence).toBe("high");
+  });
+
+  test("returns available tokens from config", async () => {
+    const configPath = await setupTestConfig(`compatibility:
+  tailwind: "4"
+colors:
+  primary: "oklch(0.6 0.15 250)"
+  secondary: "oklch(0.7 0.1 180)"
+  accent: "oklch(0.5 0.2 30)"
+`);
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    const filePath = resolve(srcDir, "Test.tsx");
+    await writeFile(
+      filePath,
+      `export function Test() {
+  return <div className="bg-primary">Test</div>;
+}
+`
+    );
+
+    const payload = await executeSuggestTool(testDir, configPath, {
+      file: filePath,
+      category: "all",
+    });
+
+    // Should include semantic color tokens
+    expect(payload.availableTokens.colors).toContain("primary");
+    expect(payload.availableTokens.colors).toContain("secondary");
+    expect(payload.availableTokens.colors).toContain("accent");
+    expect(payload.availableTokens.spacing.length).toBeGreaterThan(0);
+    expect(payload.availableTokens.typography.length).toBeGreaterThan(0);
+  });
+
+  test("includes guidance in response", async () => {
+    const configPath = await setupTestConfig(`compatibility:
+  tailwind: "4"
+`);
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    const filePath = resolve(srcDir, "Empty.tsx");
+    await writeFile(
+      filePath,
+      `export function Empty() {
+  return <div>No classes</div>;
+}
+`
+    );
+
+    const payload = await executeSuggestTool(testDir, configPath, {
+      file: filePath,
+      category: "all",
+    });
+
+    expect(payload.guidance).toBeInstanceOf(Array);
+    expect(payload.guidance.length).toBeGreaterThan(0);
+    expect(payload.guidance.some((g) => g.includes("semantic"))).toBe(true);
+  });
+
+  test("handles file with no classes gracefully", async () => {
+    const configPath = await setupTestConfig(`compatibility:
+  tailwind: "4"
+`);
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    const filePath = resolve(srcDir, "NoClasses.tsx");
+    await writeFile(
+      filePath,
+      `export function NoClasses() {
+  return <div>Plain content</div>;
+}
+`
+    );
+
+    const payload = await executeSuggestTool(testDir, configPath, {
+      file: filePath,
+      category: "all",
+    });
+
+    expect(payload.kind).toBe("suggest");
+    expect(payload.suggestions).toHaveLength(0);
+    expect(payload.availableTokens).toBeDefined();
+  });
+
+  test("suggests success/warning with medium confidence when tokens not in config", async () => {
+    const configPath = await setupTestConfig(`compatibility:
+  tailwind: "4"
+`);
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    const filePath = resolve(srcDir, "Status.tsx");
+    await writeFile(
+      filePath,
+      `export function Status() {
+  return <div className="bg-green-500 text-yellow-500">Status</div>;
+}
+`
+    );
+
+    const payload = await executeSuggestTool(testDir, configPath, {
+      file: filePath,
+      category: "colors",
+    });
+
+    const successSuggestion = payload.suggestions.find((s) => s.current === "bg-green-500");
+    expect(successSuggestion).toBeDefined();
+    expect(successSuggestion?.suggested).toContain("success");
+    expect(successSuggestion?.confidence).toBe("medium");
+    expect(successSuggestion?.reason).toContain("not found in config");
+
+    expect(payload.availableTokens.colors).not.toContain("success");
+  });
+
+  test("suggests success with high confidence when token IS in config", async () => {
+    const configPath = await setupTestConfig(`compatibility:
+  tailwind: "4"
+colors:
+  success: "oklch(0.65 0.2 145)"
+`);
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    const filePath = resolve(srcDir, "Status.tsx");
+    await writeFile(
+      filePath,
+      `export function Status() {
+  return <div className="bg-green-500">Success</div>;
+}
+`
+    );
+
+    const payload = await executeSuggestTool(testDir, configPath, {
+      file: filePath,
+      category: "colors",
+    });
+
+    const successSuggestion = payload.suggestions.find((s) => s.current === "bg-green-500");
+    expect(successSuggestion).toBeDefined();
+    expect(successSuggestion?.confidence).toBe("high");
+    expect(payload.availableTokens.colors).toContain("success");
+  });
+});
+
+describe("SuggestResponse structure", () => {
+  const testDir = resolve(import.meta.dir, ".test-fixtures-suggest-response");
+
+  beforeEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  test("has all required fields", async () => {
+    const northDir = resolve(testDir, "north");
+    const rulesDir = resolve(northDir, "rules");
+    await mkdir(rulesDir, { recursive: true });
+    const configPath = resolve(northDir, "north.config.yaml");
+    await writeFile(configPath, "compatibility:\n  tailwind: '4'");
+
+    await writeFile(
+      resolve(rulesDir, "placeholder.yaml"),
+      `id: north/placeholder
+language: tsx
+severity: "off"
+message: Placeholder
+rule:
+  kind: string_fragment
+  regex: "^$"
+`
+    );
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    const filePath = resolve(srcDir, "Test.tsx");
+    await writeFile(
+      filePath,
+      `export function Test() {
+  return <div className="bg-blue-500">Test</div>;
+}
+`
+    );
+
+    const payload: SuggestResponse = await executeSuggestTool(testDir, configPath, {
+      file: filePath,
+    });
+
+    expect(payload).toHaveProperty("kind");
+    expect(payload.kind).toBe("suggest");
+    expect(payload).toHaveProperty("file");
+    expect(payload).toHaveProperty("suggestions");
+    expect(payload).toHaveProperty("guidance");
+    expect(payload).toHaveProperty("availableTokens");
+
+    expect(payload.availableTokens).toHaveProperty("colors");
+    expect(payload.availableTokens).toHaveProperty("spacing");
+    expect(payload.availableTokens).toHaveProperty("typography");
+  });
+});
+
+describe("TokenSuggestion structure", () => {
+  const testDir = resolve(import.meta.dir, ".test-fixtures-token-suggestion");
+
+  beforeEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  test("suggestion has all required fields", async () => {
+    const northDir = resolve(testDir, "north");
+    const rulesDir = resolve(northDir, "rules");
+    await mkdir(rulesDir, { recursive: true });
+    const configPath = resolve(northDir, "north.config.yaml");
+    await writeFile(configPath, "compatibility:\n  tailwind: '4'");
+
+    await writeFile(
+      resolve(rulesDir, "placeholder.yaml"),
+      `id: north/placeholder
+language: tsx
+severity: "off"
+message: Placeholder
+rule:
+  kind: string_fragment
+  regex: "^$"
+`
+    );
+
+    const srcDir = resolve(testDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    const filePath = resolve(srcDir, "Test.tsx");
+    await writeFile(
+      filePath,
+      `export function Test() {
+  return <div className="bg-red-500 p-4">Test</div>;
+}
+`
+    );
+
+    const payload = await executeSuggestTool(testDir, configPath, {
+      file: filePath,
+    });
+
+    expect(payload.suggestions.length).toBeGreaterThan(0);
+    const suggestion = payload.suggestions[0];
+
+    expect(suggestion).toHaveProperty("current");
+    expect(suggestion).toHaveProperty("suggested");
+    expect(suggestion).toHaveProperty("category");
+    expect(suggestion).toHaveProperty("confidence");
+    expect(suggestion).toHaveProperty("reason");
+
+    expect(["color", "spacing", "typography", "other"]).toContain(suggestion?.category);
+    expect(["high", "medium", "low"]).toContain(suggestion?.confidence);
+  });
+});

--- a/packages/north/src/mcp/tools/suggest.ts
+++ b/packages/north/src/mcp/tools/suggest.ts
@@ -1,0 +1,574 @@
+/**
+ * north_suggest MCP tool - Suggest appropriate design tokens for use cases
+ *
+ * Given a file location or violation, suggests appropriate semantic tokens
+ * to replace raw values or arbitrary utilities.
+ *
+ * This is a Tier 2 tool - requires config (north.config.yaml) to be present.
+ *
+ * @see .scratch/mcp-server/11-remaining-issues-execution-plan.md for specification
+ * @issue #82
+ */
+
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { DEFAULT_COLORS_LIGHT } from "../../config/defaults.ts";
+import { loadConfig } from "../../config/loader.ts";
+import type { NorthConfig } from "../../config/schema.ts";
+import { COLOR_PREFIXES, SPACING_PREFIXES } from "../../lib/utility-classification.ts";
+import { detectContext } from "../state.ts";
+
+// ============================================================================
+// Input Schema
+// ============================================================================
+
+export const SuggestInputSchema = z.object({
+  file: z.string().describe("File path to analyze for token suggestions"),
+  line: z.number().optional().describe("Line number to focus suggestions on (1-indexed)"),
+  violation: z
+    .string()
+    .optional()
+    .describe("Violation ID or class name from north_check for targeted suggestions"),
+  category: z
+    .enum(["colors", "spacing", "typography", "all"])
+    .optional()
+    .default("all")
+    .describe("Filter suggestions by category"),
+  cwd: z.string().optional().describe("Working directory (defaults to process.cwd())"),
+});
+
+export type SuggestInput = z.infer<typeof SuggestInputSchema>;
+
+// ============================================================================
+// Response Types
+// ============================================================================
+
+/**
+ * A single token suggestion with reasoning.
+ */
+export interface TokenSuggestion {
+  /** Current value (e.g., "bg-blue-500") */
+  current: string;
+  /** Suggested replacement (e.g., "bg-primary") */
+  suggested: string;
+  /** CSS variable name if applicable */
+  cssVar?: string;
+  /** Category of the suggestion */
+  category: "color" | "spacing" | "typography" | "other";
+  /** Confidence level */
+  confidence: "high" | "medium" | "low";
+  /** Explanation for why this suggestion is appropriate */
+  reason: string;
+}
+
+/**
+ * Response payload from north_suggest tool.
+ */
+export interface SuggestResponse {
+  /** Response kind identifier */
+  kind: "suggest";
+  /** File that was analyzed */
+  file: string;
+  /** Line number if provided */
+  line?: number;
+  /** Array of suggestions */
+  suggestions: TokenSuggestion[];
+  /** General guidance for this context */
+  guidance: string[];
+  /** Available semantic tokens for reference */
+  availableTokens: {
+    colors: string[];
+    spacing: string[];
+    typography: string[];
+  };
+}
+
+// ============================================================================
+// Semantic Token Maps
+// ============================================================================
+
+const SEMANTIC_COLOR_MAP: Record<string, { token: string; reason: string }> = {
+  // Primary colors
+  "blue-500": { token: "primary", reason: "Primary action color" },
+  "blue-600": { token: "primary", reason: "Primary action color (hover state)" },
+  "blue-700": { token: "primary", reason: "Primary action color (pressed state)" },
+
+  // Neutrals / Foreground
+  "gray-900": { token: "foreground", reason: "Primary text color" },
+  "gray-800": { token: "foreground", reason: "Primary text color" },
+  "gray-700": { token: "foreground", reason: "Secondary text color" },
+
+  // Muted
+  "gray-500": { token: "muted-foreground", reason: "Muted/placeholder text" },
+  "gray-400": { token: "muted-foreground", reason: "Muted text" },
+  "gray-100": { token: "muted", reason: "Muted background" },
+  "gray-50": { token: "muted", reason: "Subtle background" },
+
+  // Borders
+  "gray-200": { token: "border", reason: "Default border color" },
+  "gray-300": { token: "border", reason: "Border color" },
+
+  // Destructive
+  "red-500": { token: "destructive", reason: "Error/destructive action" },
+  "red-600": { token: "destructive", reason: "Error/destructive action" },
+  "red-700": { token: "destructive", reason: "Error/destructive (pressed)" },
+
+  // Success
+  "green-500": { token: "success", reason: "Success state" },
+  "green-600": { token: "success", reason: "Success state" },
+
+  // Warning
+  "yellow-500": { token: "warning", reason: "Warning state" },
+  "amber-500": { token: "warning", reason: "Warning state" },
+  "orange-500": { token: "warning", reason: "Warning state" },
+
+  // Background
+  white: { token: "background", reason: "Base background" },
+  "slate-50": { token: "background", reason: "Base background" },
+  "zinc-50": { token: "background", reason: "Base background" },
+};
+
+const SEMANTIC_SPACING_MAP: Record<string, { token: string; reason: string }> = {
+  "0.5": { token: "xs", reason: "Extra small spacing (2px)" },
+  "1": { token: "xs", reason: "Extra small spacing (4px)" },
+  "1.5": { token: "sm", reason: "Small spacing (6px)" },
+  "2": { token: "sm", reason: "Small spacing (8px)" },
+  "3": { token: "md", reason: "Medium spacing (12px)" },
+  "4": { token: "md", reason: "Medium spacing (16px)" },
+  "5": { token: "lg", reason: "Large spacing (20px)" },
+  "6": { token: "lg", reason: "Large spacing (24px)" },
+  "8": { token: "xl", reason: "Extra large spacing (32px)" },
+  "10": { token: "xl", reason: "Extra large spacing (40px)" },
+  "12": { token: "2xl", reason: "2x extra large spacing (48px)" },
+  "16": { token: "2xl", reason: "2x extra large spacing (64px)" },
+};
+
+// ============================================================================
+// Parsing Utilities
+// ============================================================================
+
+function parseColorClass(
+  className: string
+): { prefix: string; color: string; opacity?: string } | null {
+  for (const prefix of COLOR_PREFIXES) {
+    const regex = new RegExp(`^${prefix}-([a-z]+-\\d+|[a-z]+)(?:/(\\d+))?$`);
+    const match = className.match(regex);
+    if (match?.[1]) {
+      return {
+        prefix,
+        color: match[1],
+        opacity: match[2],
+      };
+    }
+  }
+  return null;
+}
+
+function parseSpacingClass(className: string): { prefix: string; value: string } | null {
+  for (const prefix of SPACING_PREFIXES) {
+    if (className.startsWith(`${prefix}-`)) {
+      const value = className.slice(prefix.length + 1);
+      // Check for numeric values (including decimals and arbitrary)
+      if (/^(\d+\.?\d*|\[.+\])$/.test(value)) {
+        return { prefix, value };
+      }
+    }
+  }
+  return null;
+}
+
+function extractClassesFromLine(line: string): string[] {
+  // Match className="..." or class="..." patterns
+  const classNameMatches = line.matchAll(/(?:className|class)=["']([^"']+)["']/g);
+  const classes: string[] = [];
+
+  for (const match of classNameMatches) {
+    if (match[1]) {
+      classes.push(...match[1].split(/\s+/).filter(Boolean));
+    }
+  }
+
+  // Also match cn(...), clsx(...), cva(...) patterns
+  const utilityMatches = line.matchAll(/(?:cn|clsx|cva)\(([^)]+)\)/g);
+  for (const match of utilityMatches) {
+    if (match[1]) {
+      // Extract string literals
+      const literals = match[1].matchAll(/"([^"]+)"|'([^']+)'/g);
+      for (const lit of literals) {
+        const value = lit[1] ?? lit[2];
+        if (value) {
+          classes.push(...value.split(/\s+/).filter(Boolean));
+        }
+      }
+    }
+  }
+
+  return classes;
+}
+
+// ============================================================================
+// Suggestion Generation
+// ============================================================================
+
+function suggestColorReplacement(
+  className: string,
+  parsed: { prefix: string; color: string; opacity?: string },
+  availableColors: string[]
+): TokenSuggestion | null {
+  const mapping = SEMANTIC_COLOR_MAP[parsed.color];
+  if (!mapping) {
+    // No direct mapping, provide generic guidance
+    return {
+      current: className,
+      suggested: `${parsed.prefix}-{semantic-token}`,
+      category: "color",
+      confidence: "low",
+      reason: `Replace raw palette color "${parsed.color}" with a semantic token from your design system`,
+    };
+  }
+
+  // Validate token exists in config
+  const tokenExists = availableColors.includes(mapping.token);
+
+  const suggested = parsed.opacity
+    ? `${parsed.prefix}-${mapping.token}/${parsed.opacity}`
+    : `${parsed.prefix}-${mapping.token}`;
+
+  return {
+    current: className,
+    suggested,
+    cssVar: `--color-${mapping.token}`,
+    category: "color",
+    // Only high confidence if token exists in config
+    confidence: tokenExists ? "high" : "medium",
+    reason: tokenExists
+      ? mapping.reason
+      : `${mapping.reason} (Note: token "${mapping.token}" not found in config)`,
+  };
+}
+
+function suggestSpacingReplacement(
+  className: string,
+  parsed: { prefix: string; value: string },
+  availableSpacing: string[]
+): TokenSuggestion | null {
+  // Handle arbitrary values
+  if (parsed.value.startsWith("[")) {
+    return {
+      current: className,
+      suggested: `${parsed.prefix}-(--spacing-{token})`,
+      category: "spacing",
+      confidence: "low",
+      reason: "Replace arbitrary value with a spacing token from your design system",
+    };
+  }
+
+  const mapping = SEMANTIC_SPACING_MAP[parsed.value];
+  if (!mapping) {
+    return {
+      current: className,
+      suggested: `${parsed.prefix}-(--spacing-{token})`,
+      category: "spacing",
+      confidence: "low",
+      reason: `Consider using a semantic spacing token instead of numeric value "${parsed.value}"`,
+    };
+  }
+
+  // Validate token exists in config
+  const tokenExists = availableSpacing.includes(mapping.token);
+
+  return {
+    current: className,
+    suggested: `${parsed.prefix}-(--spacing-${mapping.token})`,
+    cssVar: `--spacing-${mapping.token}`,
+    category: "spacing",
+    // Only high confidence if token exists in config
+    confidence: tokenExists ? "high" : "medium",
+    reason: tokenExists
+      ? mapping.reason
+      : `${mapping.reason} (Note: token "${mapping.token}" not found in config)`,
+  };
+}
+
+function generateSuggestionsForClass(
+  className: string,
+  category: "colors" | "spacing" | "typography" | "all",
+  availableTokens: SuggestResponse["availableTokens"]
+): TokenSuggestion | null {
+  // Try color parsing
+  if (category === "all" || category === "colors") {
+    const colorParsed = parseColorClass(className);
+    if (colorParsed) {
+      const colorSuggestion = suggestColorReplacement(
+        className,
+        colorParsed,
+        availableTokens.colors
+      );
+      if (colorSuggestion) return colorSuggestion;
+    }
+  }
+
+  // Try spacing parsing
+  if (category === "all" || category === "spacing") {
+    const spacingParsed = parseSpacingClass(className);
+    if (spacingParsed) {
+      const spacingSuggestion = suggestSpacingReplacement(
+        className,
+        spacingParsed,
+        availableTokens.spacing
+      );
+      if (spacingSuggestion) return spacingSuggestion;
+    }
+  }
+
+  return null;
+}
+
+function buildAvailableTokens(config: NorthConfig): SuggestResponse["availableTokens"] {
+  // Start with keys from DEFAULT_COLORS_LIGHT as the baseline
+  const colors = new Set<string>(Object.keys(DEFAULT_COLORS_LIGHT));
+
+  // Enrich from config if available (may add custom tokens like success, warning)
+  if (config.colors) {
+    for (const key of Object.keys(config.colors)) {
+      colors.add(key);
+    }
+  }
+
+  // Spacing and typography remain unchanged (these are consistent defaults)
+  const spacing: string[] = ["xs", "sm", "md", "lg", "xl", "2xl"];
+  const typography: string[] = ["xs", "sm", "base", "lg", "xl", "2xl", "3xl", "4xl"];
+
+  return { colors: [...colors], spacing, typography };
+}
+
+function buildGuidance(category: "colors" | "spacing" | "typography" | "all"): string[] {
+  const guidance: string[] = [
+    "Use semantic tokens for consistency across your design system.",
+    "Run 'north check' to find all violations that need token replacement.",
+  ];
+
+  if (category === "all" || category === "colors") {
+    guidance.push(
+      "For colors: prefer semantic names like 'primary', 'foreground', 'muted' over raw palette values."
+    );
+  }
+
+  if (category === "all" || category === "spacing") {
+    guidance.push("For spacing: use --spacing-xs through --spacing-2xl instead of numeric values.");
+  }
+
+  if (category === "all" || category === "typography") {
+    guidance.push("For typography: use semantic text sizes defined in your typography scale.");
+  }
+
+  return guidance;
+}
+
+// ============================================================================
+// Core Logic
+// ============================================================================
+
+export interface SuggestOptions {
+  file: string;
+  line?: number;
+  violation?: string;
+  category?: "colors" | "spacing" | "typography" | "all";
+}
+
+/**
+ * Execute the north_suggest tool handler.
+ *
+ * Analyzes a file location and suggests appropriate design tokens.
+ */
+export async function executeSuggestTool(
+  workingDir: string,
+  configPath: string,
+  options: SuggestOptions
+): Promise<SuggestResponse> {
+  const { file, line, violation, category = "all" } = options;
+
+  // Load config
+  const loadResult = await loadConfig(configPath);
+  if (!loadResult.success) {
+    throw new Error(loadResult.error.message);
+  }
+
+  const config = loadResult.config;
+  const filePath = resolve(workingDir, file);
+
+  // Build available tokens from config first (for validation)
+  const availableTokens = buildAvailableTokens(config);
+
+  // Read file content
+  let fileContent: string;
+  try {
+    fileContent = await readFile(filePath, "utf-8");
+  } catch {
+    throw new Error(`Could not read file: ${file}`);
+  }
+
+  const lines = fileContent.split("\n");
+  const suggestions: TokenSuggestion[] = [];
+
+  // If violation is provided, focus on that specific class
+  if (violation) {
+    const suggestion = generateSuggestionsForClass(violation, category, availableTokens);
+    if (suggestion) {
+      suggestions.push(suggestion);
+    }
+  } else if (line !== undefined) {
+    // Analyze specific line
+    const lineIndex = line - 1;
+    if (lineIndex >= 0 && lineIndex < lines.length) {
+      const lineContent = lines[lineIndex] ?? "";
+      const classes = extractClassesFromLine(lineContent);
+
+      for (const cls of classes) {
+        const suggestion = generateSuggestionsForClass(cls, category, availableTokens);
+        if (suggestion) {
+          suggestions.push(suggestion);
+        }
+      }
+    }
+  } else {
+    // Analyze entire file (limit to first 10 suggestions)
+    for (const lineContent of lines) {
+      const classes = extractClassesFromLine(lineContent);
+      for (const cls of classes) {
+        const suggestion = generateSuggestionsForClass(cls, category, availableTokens);
+        if (suggestion && suggestions.length < 10) {
+          // Avoid duplicates
+          if (!suggestions.some((s) => s.current === suggestion.current)) {
+            suggestions.push(suggestion);
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    kind: "suggest",
+    file,
+    line,
+    suggestions,
+    guidance: buildGuidance(category),
+    availableTokens,
+  };
+}
+
+// ============================================================================
+// Tool Registration
+// ============================================================================
+
+/**
+ * Register the north_suggest tool with the MCP server.
+ *
+ * This is a Tier 2 tool - requires config (north.config.yaml) to be present.
+ */
+export function registerSuggestTool(server: McpServer): void {
+  server.registerTool(
+    "north_suggest",
+    {
+      description:
+        "Suggest appropriate design tokens for a file or specific class. " +
+        "Parameters: file (string) - file path, line (number) - optional line number, " +
+        "violation (string) - optional class name to get suggestions for, " +
+        "category (string) - filter by colors/spacing/typography/all.",
+      inputSchema: SuggestInputSchema,
+    },
+    async (args: unknown) => {
+      const cwd = process.cwd();
+
+      // Validate input
+      const parseResult = SuggestInputSchema.safeParse(args);
+      if (!parseResult.success) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: false,
+                  error: "Invalid input parameters",
+                  details: parseResult.error.issues,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const input = parseResult.data;
+      const workingDir = input.cwd ?? cwd;
+
+      // Check context state - this tool requires at least config state (Tier 2)
+      const ctx = await detectContext(workingDir);
+      if (ctx.state === "none") {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: false,
+                  error: "No North configuration found",
+                  guidance: [
+                    "Run 'north init' to initialize the project.",
+                    "Then run 'north gen' to generate design tokens.",
+                  ],
+                },
+                null,
+                2
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      try {
+        // configPath is guaranteed to exist when state !== 'none'
+        const configPath = ctx.configPath as string;
+        const payload = await executeSuggestTool(workingDir, configPath, {
+          file: input.file,
+          line: input.line,
+          violation: input.violation,
+          category: input.category,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(payload, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: false,
+                  error: message,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary

Adds `north_suggest` MCP tool (Tier 3) that suggests tokens for arbitrary values.

## Changes

- Match input values against indexed tokens
- Support exact matches and fuzzy matching
- Return ranked suggestions with confidence scores
- Include token metadata and usage context

## Test Plan

- [x] Typecheck passes
- [x] Lint passes
- [x] Tool requires index