### PR TITLE
chore: hide repeated-spacing-pattern config

### DIFF
--- a/packages/north/src/commands/context.ts
+++ b/packages/north/src/commands/context.ts
@@ -62,7 +62,6 @@ const RULE_KEYS = [
   "no-raw-palette",
   "no-arbitrary-colors",
   "no-arbitrary-values",
-  "repeated-spacing-pattern",
   "component-complexity",
   "deviation-tracking",
 ] as const;

--- a/packages/north/src/config/defaults.ts
+++ b/packages/north/src/config/defaults.ts
@@ -83,10 +83,6 @@ export const DEFAULT_CONFIG: NorthConfig = {
     "no-raw-palette": "error",
     "no-arbitrary-colors": "error",
     "no-arbitrary-values": "error",
-    "repeated-spacing-pattern": {
-      level: "warn",
-      threshold: 3,
-    },
     "component-complexity": {
       level: "warn",
       "max-classes": 15,
@@ -157,10 +153,6 @@ rules:
   no-raw-palette: error
   no-arbitrary-colors: error
   no-arbitrary-values: error
-
-  repeated-spacing-pattern:
-    level: warn
-    threshold: 3
 
   component-complexity:
     level: warn

--- a/packages/north/src/config/schema.ts
+++ b/packages/north/src/config/schema.ts
@@ -125,13 +125,6 @@ export const RulesConfigSchema = z
     "no-raw-palette": SimpleRuleConfigSchema.optional(),
     "no-arbitrary-colors": SimpleRuleConfigSchema.optional(),
     "no-arbitrary-values": SimpleRuleConfigSchema.optional(),
-    "repeated-spacing-pattern": z
-      .object({
-        level: RuleLevelSchema.optional(),
-        ignore: z.array(z.string()).optional(),
-        threshold: z.number().int().min(1).optional(),
-      })
-      .optional(),
     "component-complexity": z
       .object({
         level: RuleLevelSchema.optional(),

--- a/packages/north/src/mcp/tools/context.ts
+++ b/packages/north/src/mcp/tools/context.ts
@@ -49,7 +49,6 @@ const RULE_KEYS = [
   "no-raw-palette",
   "no-arbitrary-colors",
   "no-arbitrary-values",
-  "repeated-spacing-pattern",
   "component-complexity",
   "deviation-tracking",
 ] as const;


### PR DESCRIPTION
## Summary
- Hide repeated-spacing-pattern from config defaults and schema until implemented.

## Changes
- Remove rule exposure from defaults/schema so it is not advertised.
- Keep rule disabled for this release.

## Testing
- bun test
