### PR TITLE
feat: derive version from package.json

### DIFF
--- a/packages/north/src/cli/index.ts
+++ b/packages/north/src/cli/index.ts
@@ -11,15 +11,14 @@ import { init } from "../commands/init.ts";
 import { migrate } from "../commands/migrate.ts";
 import { promote } from "../commands/promote.ts";
 import { refactor } from "../commands/refactor.ts";
-
-const VERSION = "0.1.0";
+import { version } from "../version.ts";
 
 const program = new Command();
 
 program
   .name("north")
   .description("Design system enforcement CLI tool")
-  .version(VERSION, "-v, --version", "Output the current version");
+  .version(version, "-v, --version", "Output the current version");
 
 // ============================================================================
 // init - Initialize North in project

--- a/packages/north/src/index.ts
+++ b/packages/north/src/index.ts
@@ -1,6 +1,6 @@
 // Main library entry point
 
-export const version = "0.1.0";
+export { version } from "./version.ts";
 
 // Config exports
 export {

--- a/packages/north/src/mcp/server.ts
+++ b/packages/north/src/mcp/server.ts
@@ -25,6 +25,7 @@ import { registerQueryTool } from "./tools/query.ts";
 import { registerRefactorTool } from "./tools/refactor.ts";
 import { registerSuggestTool } from "./tools/suggest.ts";
 import type { ServerState } from "./types.ts";
+import { version } from "../version.ts";
 
 // Re-export getGuidance for backward compatibility with tests
 export { getGuidance };
@@ -34,7 +35,6 @@ export { getGuidance };
 // ============================================================================
 
 const SERVER_NAME = "north";
-const SERVER_VERSION = "0.1.0";
 
 /**
  * Server instructions for Claude Code Tool Search discovery.
@@ -245,7 +245,7 @@ export function createServer(): McpServer {
   const server = new McpServer(
     {
       name: SERVER_NAME,
-      version: SERVER_VERSION,
+      version,
     },
     {
       capabilities: {

--- a/packages/north/src/version.ts
+++ b/packages/north/src/version.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function readPackageVersion(): string {
+  const packagePath = resolve(dirname(fileURLToPath(import.meta.url)), "../package.json");
+
+  try {
+    const content = readFileSync(packagePath, "utf-8");
+    const data = JSON.parse(content) as { version?: string };
+    return typeof data.version === "string" ? data.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+export const version = readPackageVersion();


### PR DESCRIPTION
## Summary
- Use package.json as the single source of truth for version.

## Changes
- Add version helper that reads package.json via import.meta.url with fallback.
- Remove duplicated hardcoded versions.

## Testing
- bun test
