### PR TITLE
feat: expand MCP file globs

### DIFF
--- a/packages/north/src/mcp/server.ts
+++ b/packages/north/src/mcp/server.ts
@@ -7,6 +7,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { version } from "../version.ts";
 import { registerAdoptTool } from "./tools/adopt-tool.ts";
 import { registerCheckTool } from "./tools/check.ts";
 import { registerClassifyTool } from "./tools/classify-tool.ts";
@@ -25,7 +26,6 @@ import { registerQueryTool } from "./tools/query.ts";
 import { registerRefactorTool } from "./tools/refactor.ts";
 import { registerSuggestTool } from "./tools/suggest.ts";
 import type { ServerState } from "./types.ts";
-import { version } from "../version.ts";
 
 // Re-export getGuidance for backward compatibility with tests
 export { getGuidance };


### PR DESCRIPTION
## Summary
- Expand MCP file globs with CLI-parity behavior.

## Changes
- Detect brace patterns as globs and expand them.
- Treat existing explicit file paths as literals (including bracketed Next.js routes).

## Testing
- bun test
