### PR TITLE
feat: unify rule config shape

### DIFF
--- a/examples/nextjs-shadcn/north/north.config.yaml
+++ b/examples/nextjs-shadcn/north/north.config.yaml
@@ -29,21 +29,22 @@ policy:
 
 # Rule configuration
 rules:
-  no-raw-palette: error
-  no-arbitrary-colors: error
-  no-arbitrary-values: error
-
-  repeated-spacing-pattern:
-    level: warn
-    threshold: 3
+  no-raw-palette:
+    level: error
+  no-arbitrary-colors:
+    level: error
+  no-arbitrary-values:
+    level: error
 
   component-complexity:
     level: warn
-    max-classes: 15
+    options:
+      max-classes: 15
 
   deviation-tracking:
     level: info
-    promote-threshold: 3
+    options:
+      promote-threshold: 3
 
 # Third-party component policy
 third-party:

--- a/packages/north/src/commands/context.ts
+++ b/packages/north/src/commands/context.ts
@@ -62,7 +62,11 @@ const RULE_KEYS = [
   "no-raw-palette",
   "no-arbitrary-colors",
   "no-arbitrary-values",
+  "non-literal-classname",
+  "no-inline-color",
   "component-complexity",
+  "missing-semantic-comment",
+  "parse-error",
   "deviation-tracking",
 ] as const;
 

--- a/packages/north/src/commands/doctor.ts
+++ b/packages/north/src/commands/doctor.ts
@@ -292,11 +292,22 @@ export async function doctor(options: DoctorOptions = {}): Promise<DoctorResult>
         let source = "default";
 
         if (deviationRule && typeof deviationRule === "object") {
-          const threshold = (deviationRule as { "promote-threshold"?: number })[
-            "promote-threshold"
-          ];
-          if (typeof threshold === "number") {
-            promoteThreshold = threshold;
+          const options = (deviationRule as { options?: Record<string, unknown> }).options;
+          const optionThreshold =
+            options && typeof options["promote-threshold"] === "number"
+              ? (options["promote-threshold"] as number)
+              : undefined;
+          const legacyThreshold =
+            typeof (deviationRule as { "promote-threshold"?: number })["promote-threshold"] ===
+            "number"
+              ? ((deviationRule as { "promote-threshold"?: number })["promote-threshold"] as number)
+              : undefined;
+
+          if (typeof optionThreshold === "number") {
+            promoteThreshold = optionThreshold;
+            source = "config (rules.deviation-tracking.options.promote-threshold)";
+          } else if (typeof legacyThreshold === "number") {
+            promoteThreshold = legacyThreshold;
             source = "config (rules.deviation-tracking.promote-threshold)";
           }
         }

--- a/packages/north/src/config/defaults.ts
+++ b/packages/north/src/config/defaults.ts
@@ -80,16 +80,20 @@ export const DEFAULT_CONFIG: NorthConfig = {
   },
   colors: DEFAULT_COLORS_LIGHT,
   rules: {
-    "no-raw-palette": "error",
-    "no-arbitrary-colors": "error",
-    "no-arbitrary-values": "error",
+    "no-raw-palette": { level: "error" },
+    "no-arbitrary-colors": { level: "error" },
+    "no-arbitrary-values": { level: "error" },
     "component-complexity": {
       level: "warn",
-      "max-classes": 15,
+      options: {
+        "max-classes": 15,
+      },
     },
     "deviation-tracking": {
       level: "info",
-      "promote-threshold": 3,
+      options: {
+        "promote-threshold": 3,
+      },
     },
   },
   "third-party": {
@@ -150,17 +154,22 @@ policy:
 
 # Rule configuration
 rules:
-  no-raw-palette: error
-  no-arbitrary-colors: error
-  no-arbitrary-values: error
+  no-raw-palette:
+    level: error
+  no-arbitrary-colors:
+    level: error
+  no-arbitrary-values:
+    level: error
 
   component-complexity:
     level: warn
-    max-classes: 15
+    options:
+      max-classes: 15
 
   deviation-tracking:
     level: info
-    promote-threshold: 3
+    options:
+      promote-threshold: 3
 
 # Lint configuration (optional)
 # lint:

--- a/packages/north/src/config/schema.ts
+++ b/packages/north/src/config/schema.ts
@@ -111,36 +111,28 @@ export type ColorsConfig = z.infer<typeof ColorsConfigSchema>;
 export const RuleLevelSchema = z.enum(["error", "warn", "info", "off"]);
 export type RuleLevel = z.infer<typeof RuleLevelSchema>;
 
-/** Base rule config with optional level and per-rule file ignores */
-export const BaseRuleConfigSchema = z.object({
+/** Uniform rule config with optional level, ignores, and options */
+export const RuleConfigSchema = z.object({
   level: RuleLevelSchema.optional(),
   ignore: z.array(z.string()).optional(),
+  options: z.record(z.string(), z.unknown()).optional(),
 });
-
-/** Rule config that accepts either a level string or an object with level and ignore */
-export const SimpleRuleConfigSchema = z.union([RuleLevelSchema, BaseRuleConfigSchema]);
+export type RuleConfig = z.infer<typeof RuleConfigSchema>;
 
 export const RulesConfigSchema = z
   .object({
-    "no-raw-palette": SimpleRuleConfigSchema.optional(),
-    "no-arbitrary-colors": SimpleRuleConfigSchema.optional(),
-    "no-arbitrary-values": SimpleRuleConfigSchema.optional(),
-    "component-complexity": z
-      .object({
-        level: RuleLevelSchema.optional(),
-        ignore: z.array(z.string()).optional(),
-        "max-classes": z.number().int().min(1).optional(),
-      })
-      .optional(),
-    "deviation-tracking": z
-      .object({
-        level: RuleLevelSchema.optional(),
-        ignore: z.array(z.string()).optional(),
-        "promote-threshold": z.number().int().min(1).optional(),
-      })
-      .optional(),
-    "extract-repeated-classes": SimpleRuleConfigSchema.optional(),
+    "no-raw-palette": RuleConfigSchema.optional(),
+    "no-arbitrary-colors": RuleConfigSchema.optional(),
+    "no-arbitrary-values": RuleConfigSchema.optional(),
+    "non-literal-classname": RuleConfigSchema.optional(),
+    "no-inline-color": RuleConfigSchema.optional(),
+    "component-complexity": RuleConfigSchema.optional(),
+    "missing-semantic-comment": RuleConfigSchema.optional(),
+    "parse-error": RuleConfigSchema.optional(),
+    "deviation-tracking": RuleConfigSchema.optional(),
+    "extract-repeated-classes": RuleConfigSchema.optional(),
   })
+  .catchall(RuleConfigSchema)
   .optional();
 
 export type RulesConfig = z.infer<typeof RulesConfigSchema>;

--- a/packages/north/src/mcp/tools/context.test.ts
+++ b/packages/north/src/mcp/tools/context.test.ts
@@ -77,8 +77,10 @@ compatibility:
 compatibility:
   tailwind: "4"
 rules:
-  no-raw-palette: error
-  no-arbitrary-colors: warn
+  no-raw-palette:
+    level: error
+  no-arbitrary-colors:
+    level: warn
 `
     );
 

--- a/packages/north/src/mcp/tools/context.ts
+++ b/packages/north/src/mcp/tools/context.ts
@@ -49,7 +49,11 @@ const RULE_KEYS = [
   "no-raw-palette",
   "no-arbitrary-colors",
   "no-arbitrary-values",
+  "non-literal-classname",
+  "no-inline-color",
   "component-complexity",
+  "missing-semantic-comment",
+  "parse-error",
   "deviation-tracking",
 ] as const;
 

--- a/packages/north/src/mcp/tools/refactor.test.ts
+++ b/packages/north/src/mcp/tools/refactor.test.ts
@@ -28,8 +28,10 @@ describe("executeRefactorTool", () => {
 compatibility:
   tailwind: "4"
 rules:
-  no-raw-palette: error
-  no-arbitrary-colors: error
+  no-raw-palette:
+    level: error
+  no-arbitrary-colors:
+    level: error
 `
     );
 


### PR DESCRIPTION
## Summary
- Unify rule config shape across built-in and custom rules.

## Changes
- Normalize rule configs to { level, ignore, options } in schema and loader.
- Preserve legacy options mapping for backward compatibility.

## Testing
- bun test
