### PR TITLE
feat: support npm and registry config extends

### DIFF
--- a/packages/north/src/config/loader.ts
+++ b/packages/north/src/config/loader.ts
@@ -1,9 +1,11 @@
-import { readFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { access, readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { parse as parseYAML } from "yaml";
 import { applyDefaults } from "./defaults.ts";
 import { findConfigFile } from "./env.ts";
-import { type NorthConfig, validateConfig } from "./schema.ts";
+import { type NorthConfig, type RegistryConfig, validateConfig } from "./schema.ts";
 
 // ============================================================================
 // Error Types
@@ -55,6 +57,223 @@ export type LoadConfigResult =
 // Core Loader Functions
 // ============================================================================
 
+type ConfigSource =
+  | { type: "file"; id: string; path: string }
+  | { type: "url"; id: string; url: string };
+
+const DEFAULT_PRESET_FILES = ["north.config.yaml", "north.config.yml", "north.config.json"];
+
+function isUrl(value: string): boolean {
+  return value.startsWith("http://") || value.startsWith("https://");
+}
+
+function isWindowsAbsolutePath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function isFileReference(value: string): boolean {
+  return value.startsWith(".") || value.startsWith("/") || isWindowsAbsolutePath(value);
+}
+
+function looksLikeConfigFile(value: string): boolean {
+  return /\.(ya?ml|json)$/i.test(value);
+}
+
+function normalizeExtends(extendsValue: NorthConfig["extends"]): string[] {
+  if (!extendsValue) return [];
+  return Array.isArray(extendsValue) ? extendsValue : [extendsValue];
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parsePackageReference(value: string): { packageName: string; subpath?: string } {
+  if (value.startsWith("@")) {
+    const parts = value.split("/");
+    const packageName = parts.slice(0, 2).join("/");
+    const subpath = parts.slice(2).join("/");
+    return { packageName, subpath: subpath || undefined };
+  }
+
+  const [packageName = value, ...rest] = value.split("/");
+  const subpath = rest.join("/");
+  return { packageName, subpath: subpath || undefined };
+}
+
+async function resolvePackageConfigPath(
+  value: string,
+  baseDir: string
+): Promise<{ success: true; path: string } | { success: false; error: Error }> {
+  const { packageName, subpath } = parsePackageReference(value);
+  const requireFromBase = createRequire(resolve(baseDir, "package.json"));
+
+  let packageJsonPath: string;
+  try {
+    packageJsonPath = requireFromBase.resolve(`${packageName}/package.json`);
+  } catch (error) {
+    return {
+      success: false,
+      error: new Error(
+        `Unable to resolve npm package "${packageName}" from ${baseDir}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      ),
+    };
+  }
+
+  const packageRoot = dirname(packageJsonPath);
+
+  if (subpath) {
+    const resolved = resolve(packageRoot, subpath);
+    if (await fileExists(resolved)) {
+      return { success: true, path: resolved };
+    }
+    return {
+      success: false,
+      error: new Error(`Preset path not found: ${resolved}`),
+    };
+  }
+
+  let packageJson: { north?: unknown } | null = null;
+  try {
+    const content = await readFile(packageJsonPath, "utf-8");
+    packageJson = JSON.parse(content) as { north?: unknown };
+  } catch (error) {
+    return {
+      success: false,
+      error: new Error(
+        `Failed to read ${packageName} package.json: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      ),
+    };
+  }
+
+  const northField = packageJson?.north;
+  const candidatePaths: string[] = [];
+  if (typeof northField === "string") {
+    candidatePaths.push(northField);
+  } else if (northField && typeof northField === "object") {
+    const configPath = (northField as { config?: unknown; preset?: unknown; path?: unknown })
+      .config;
+    const presetPath = (northField as { config?: unknown; preset?: unknown; path?: unknown })
+      .preset;
+    const genericPath = (northField as { config?: unknown; preset?: unknown; path?: unknown }).path;
+    if (typeof configPath === "string") candidatePaths.push(configPath);
+    if (typeof presetPath === "string") candidatePaths.push(presetPath);
+    if (typeof genericPath === "string") candidatePaths.push(genericPath);
+  }
+
+  const resolvedCandidates = (
+    candidatePaths.length > 0 ? candidatePaths : DEFAULT_PRESET_FILES
+  ).map((candidate) => resolve(packageRoot, candidate));
+
+  for (const candidate of resolvedCandidates) {
+    if (await fileExists(candidate)) {
+      return { success: true, path: candidate };
+    }
+  }
+
+  return {
+    success: false,
+    error: new Error(
+      `No north config found in "${packageName}". Looked for ${resolvedCandidates
+        .map((candidate) => `"${candidate}"`)
+        .join(", ")}`
+    ),
+  };
+}
+
+function resolveRegistryUrl(value: string, registry?: RegistryConfig): string | null {
+  if (!registry?.url) return null;
+  const name =
+    registry.namespace && !value.startsWith(registry.namespace)
+      ? `${registry.namespace}/${value}`
+      : value;
+
+  if (registry.url.includes("{name}")) {
+    return registry.url.replace("{name}", name);
+  }
+
+  const trimmed = registry.url.endsWith("/") ? registry.url.slice(0, -1) : registry.url;
+  return `${trimmed}/${name}.json`;
+}
+
+async function resolveExtendsSource(
+  extendsPath: string,
+  configPath: string,
+  registry?: RegistryConfig
+): Promise<{ success: true; source: ConfigSource } | { success: false; error: Error }> {
+  if (isUrl(extendsPath)) {
+    return {
+      success: true,
+      source: {
+        type: "url",
+        id: extendsPath,
+        url: extendsPath,
+      },
+    };
+  }
+
+  if (isFileReference(extendsPath)) {
+    if (isUrl(configPath)) {
+      const url = new URL(extendsPath, configPath).toString();
+      return {
+        success: true,
+        source: { type: "url", id: url, url },
+      };
+    }
+
+    const baseDir = dirname(configPath);
+    const resolved = resolve(baseDir, extendsPath);
+    return {
+      success: true,
+      source: { type: "file", id: resolved, path: resolved },
+    };
+  }
+
+  const baseDir = isUrl(configPath) ? process.cwd() : dirname(configPath);
+
+  if (!isUrl(configPath) && looksLikeConfigFile(extendsPath)) {
+    const resolved = resolve(baseDir, extendsPath);
+    if (await fileExists(resolved)) {
+      return {
+        success: true,
+        source: { type: "file", id: resolved, path: resolved },
+      };
+    }
+  }
+
+  const packageResult = await resolvePackageConfigPath(extendsPath, baseDir);
+  if (packageResult.success) {
+    return {
+      success: true,
+      source: { type: "file", id: packageResult.path, path: packageResult.path },
+    };
+  }
+
+  const registryUrl = resolveRegistryUrl(extendsPath, registry);
+  if (registryUrl) {
+    return {
+      success: true,
+      source: { type: "url", id: registryUrl, url: registryUrl },
+    };
+  }
+
+  return {
+    success: false,
+    error: new Error(
+      `Unable to resolve extends "${extendsPath}" as file path, npm package, or registry URL. ${packageResult.error.message}`
+    ),
+  };
+}
+
 /**
  * Load and parse YAML config file
  */
@@ -84,6 +303,45 @@ async function readConfigFile(
   }
 }
 
+async function readConfigUrl(
+  url: string
+): Promise<{ success: true; data: unknown } | { success: false; error: ConfigLoadError }> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      return {
+        success: false,
+        error: new ConfigLoadError(
+          `Failed to fetch config: ${response.status} ${response.statusText}`,
+          url
+        ),
+      };
+    }
+    const content = await response.text();
+    const data = parseYAML(content);
+    return { success: true, data };
+  } catch (error) {
+    return {
+      success: false,
+      error: new ConfigLoadError(
+        `Failed to fetch config: ${error instanceof Error ? error.message : String(error)}`,
+        url,
+        error
+      ),
+    };
+  }
+}
+
+async function readConfigSource(
+  source: ConfigSource
+): Promise<{ success: true; data: unknown } | { success: false; error: ConfigLoadError }> {
+  if (source.type === "url") {
+    return readConfigUrl(source.url);
+  }
+
+  return readConfigFile(source.path);
+}
+
 /**
  * Recursively resolve extends chain
  */
@@ -106,75 +364,74 @@ async function resolveExtends(
 
   visitedPaths.add(configPath);
 
-  // No extends, return as-is
-  if (!config.extends) {
-    return { success: true, config };
+  try {
+    const extendsEntries = normalizeExtends(config.extends);
+
+    // No extends, return as-is
+    if (extendsEntries.length === 0) {
+      return { success: true, config };
+    }
+
+    let mergedParent: Partial<NorthConfig> | null = null;
+
+    for (const extendsPath of extendsEntries) {
+      const resolvedSource = await resolveExtendsSource(extendsPath, configPath, config.registry);
+      if (!resolvedSource.success) {
+        return {
+          success: false,
+          error: new ConfigExtendsError(
+            resolvedSource.error.message,
+            configPath,
+            extendsPath,
+            resolvedSource.error
+          ),
+        };
+      }
+
+      const parentResult = await readConfigSource(resolvedSource.source);
+      if (!parentResult.success) {
+        return {
+          success: false,
+          error: new ConfigExtendsError(
+            `Failed to load extended config: ${parentResult.error.message}`,
+            configPath,
+            extendsPath,
+            parentResult.error
+          ),
+        };
+      }
+
+      const parentValidation = validateConfig(parentResult.data);
+      if (!parentValidation.success) {
+        return {
+          success: false,
+          error: new ConfigExtendsError(
+            `Extended config is invalid: ${parentValidation.error.message}`,
+            configPath,
+            extendsPath,
+            parentValidation.error
+          ),
+        };
+      }
+
+      const resolvedParentResult = await resolveExtends(
+        parentValidation.data,
+        resolvedSource.source.id,
+        visitedPaths
+      );
+
+      if (!resolvedParentResult.success) {
+        return resolvedParentResult;
+      }
+
+      mergedParent = mergeConfigs(mergedParent ?? {}, resolvedParentResult.config);
+    }
+
+    const merged = mergeConfigs(mergedParent ?? {}, config);
+    return { success: true, config: merged };
+  } finally {
+    visitedPaths.delete(configPath);
   }
-
-  // v0.1: Only support local file paths (not npm packages or remote URLs)
-  const extendsPath = config.extends;
-  if (
-    extendsPath.startsWith("@") ||
-    extendsPath.startsWith("http://") ||
-    extendsPath.startsWith("https://")
-  ) {
-    return {
-      success: false,
-      error: new ConfigExtendsError(
-        `Remote extends not supported in v0.1. Use local file paths only. Got: ${extendsPath}`,
-        configPath,
-        extendsPath
-      ),
-    };
-  }
-
-  // Resolve relative path from current config directory
-  const baseDir = dirname(configPath);
-  const parentPath = resolve(baseDir, extendsPath);
-
-  // Load parent config
-  const parentResult = await readConfigFile(parentPath);
-  if (!parentResult.success) {
-    return {
-      success: false,
-      error: new ConfigExtendsError(
-        `Failed to load extended config: ${parentResult.error.message}`,
-        configPath,
-        parentPath,
-        parentResult.error
-      ),
-    };
-  }
-
-  // Validate parent config structure (loose validation, doesn't need to be complete)
-  const parentValidation = validateConfig(parentResult.data);
-  if (!parentValidation.success) {
-    return {
-      success: false,
-      error: new ConfigExtendsError(
-        `Extended config is invalid: ${parentValidation.error.message}`,
-        configPath,
-        parentPath,
-        parentValidation.error
-      ),
-    };
-  }
-
-  // Recursively resolve parent's extends
-  const resolvedParentResult = await resolveExtends(
-    parentValidation.data,
-    parentPath,
-    visitedPaths
-  );
-
-  if (!resolvedParentResult.success) {
-    return resolvedParentResult;
-  }
-
-  // Merge: child overrides parent
-  const merged = mergeConfigs(resolvedParentResult.config, config);
-
-  return { success: true, config: merged };
 }
 
 /**

--- a/packages/north/src/config/schema.ts
+++ b/packages/north/src/config/schema.ts
@@ -218,7 +218,10 @@ export type IndexConfig = z.infer<typeof IndexConfigSchema>;
 // ============================================================================
 
 export const NorthConfigSchema = z.object({
-  extends: z.string().nullable().optional(),
+  extends: z
+    .union([z.string(), z.array(z.string())])
+    .nullable()
+    .optional(),
   dials: DialsConfigSchema.optional(),
   typography: TypographyConfigSchema.optional(),
   policy: PolicyConfigSchema.optional(),


### PR DESCRIPTION
## Summary
- Support extends from npm, registry, and local config files.

## Changes
- Resolve npm package and registry presets in extends.
- Treat bare relative config files as file extends when the file exists.

## Testing
- bun test
