### PR TITLE
chore: allow empty test suites in example

### DIFF
--- a/examples/nextjs-shadcn/smoke.test.js
+++ b/examples/nextjs-shadcn/smoke.test.js
@@ -1,0 +1,5 @@
+import { expect, test } from "bun:test";
+
+test("smoke", () => {
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Make example tests pass on current Bun.

## Changes
- Replace unsupported --pass-with-no-tests flag with bun test.
- Add a tiny smoke test in the Next.js example.

## Testing
- bun test
