### PR TITLE
docs: update extends sources and rule config examples

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -267,6 +267,8 @@ The principles are portable—SwiftUI, Flutter, and other platforms are future e
 └─────────────────────────────────────────┘
 ```
 
+Extends can point to in-repo presets, npm packages, or registry URLs. When multiple presets are listed, they are applied in order and later layers win.
+
 ---
 
 ## The Philosophy

--- a/PLAN.md
+++ b/PLAN.md
@@ -275,7 +275,7 @@ const classNames = root.findAll({
 - [ ] Define `north.config.yaml` schema (TypeScript types + runtime validation)
 - [ ] Zod schema for config validation (TS types alone won't guard user YAML)
 - [ ] Config loader with validation
-- [ ] `extends` resolution (local files only for v0.1)
+- [ ] `extends` resolution (local files, npm packages, registry URLs; last-wins merge)
 - [ ] Dial defaults
 
 #### 1.2 Token Generation

--- a/docs/plan/01-config-generation.md
+++ b/docs/plan/01-config-generation.md
@@ -18,7 +18,7 @@ This phase implements the configuration system and token generation engine. By t
 - [ ] Define `north.config.yaml` schema (TypeScript types + runtime validation)
 - [ ] Zod schema for config validation (TS types alone won't guard user YAML)
 - [ ] Config loader with validation
-- [ ] `extends` resolution (local files only for v0.1)
+- [ ] `extends` resolution (local files, npm packages, registry URLs; last-wins merge)
 - [ ] Dial defaults
 
 ### 1.2 Token Generation
@@ -101,5 +101,5 @@ Start building the doctor command early as a debugging aid during development. I
 
 - Config is the source of truth for the entire system
 - Generated files are derived artifacts (can be regenerated)
-- `extends` resolution is local files only for v0.1 (no remote/npm)
+- `extends` resolution supports local files, npm packages, and registry URLs; later layers win
 - Keep dial system simple initially - can expand later

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -7,8 +7,11 @@
 ```yaml
 # yaml-language-server: $schema=https://north.dev/schema.json
 
-# Extend from org or base
-extends: "@myorg/north-base"  # or null for standalone
+# Extend from local, npm, or registry presets (order matters, last wins)
+extends:
+  - "./presets/base.yaml"
+  - "@myorg/north-base"
+  # - "https://registry.myorg.com/north/base.json"
 
 # Style dials
 dials:
@@ -33,22 +36,23 @@ policy:
 # Rule configuration
 rules:
   # Hard errors (cannot be downgraded)
-  no-raw-palette: error
-  no-arbitrary-colors: error
-  no-arbitrary-values: error
-  
+  no-raw-palette:
+    level: error
+  no-arbitrary-colors:
+    level: error
+  no-arbitrary-values:
+    level: error
+
   # Configurable warnings
-  repeated-spacing-pattern:
-    level: warn
-    threshold: 3          # Flag after N occurrences
-    
   component-complexity:
     level: warn
-    max-classes: 15       # Raise/lower per project needs
-    
+    options:
+      max-classes: 15       # Raise/lower per project needs
+
   deviation-tracking:
     level: info
-    promote-threshold: 3  # Suggest system addition after N deviations
+    options:
+      promote-threshold: 3  # Suggest system addition after N deviations
 
 # Third-party component policy
 third-party:
@@ -72,4 +76,3 @@ registry:
   namespace: "@myorg"
   url: "https://registry.myorg.com/north/{name}.json"
 ```
-

--- a/docs/spec/16-registry-distribution.md
+++ b/docs/spec/16-registry-distribution.md
@@ -28,6 +28,16 @@ North uses a shadcn-compatible registry format for distributing tokens, rules, a
 - Review changes before accepting
 - Once pulled, you own the code
 
+### Extends Sources
+
+North supports multiple preset sources:
+
+- In-repo presets: `extends: ["./presets/base.yaml"]`
+- npm packages: `extends: ["@myorg/north-base"]`
+- Registry URLs (direct or via `registry.url`): `extends: ["https://registry.myorg.com/north/base.json"]`
+
+When multiple presets are listed, they are applied in order and later layers win.
+
 ### Registry Item Types
 
 ```json
@@ -49,4 +59,3 @@ North uses a shadcn-compatible registry format for distributing tokens, rules, a
   }
 }
 ```
-


### PR DESCRIPTION
## Summary
- Document new extends sources and uniform rule config.

## Changes
- Update docs with npm/registry/in-repo extends examples.
- Refresh rule config examples to use { level, ignore, options }.

## Testing
- Not run (docs only)
