### PR TITLE
fix: correct repeated-spacing option fallback

### DIFF
--- a/packages/north/src/lint/repeated-spacing.test.ts
+++ b/packages/north/src/lint/repeated-spacing.test.ts
@@ -18,7 +18,7 @@ describe("repeated-spacing-pattern", () => {
   });
 
   test("respects allow-after-line-start option", () => {
-    const source = "export function Example() { return <p>Foo\\n  bar</p>; }";
+    const source = "export function Example() { return <p>Foo\n  bar</p>; }";
     const issues = extractRepeatedSpacingIssues(source, "Example.tsx", "warn", {
       "allow-after-line-start": false,
     });

--- a/packages/north/src/lint/repeated-spacing.ts
+++ b/packages/north/src/lint/repeated-spacing.ts
@@ -32,7 +32,7 @@ function readStringArray(value: unknown): string[] | null {
     return null;
   }
   const strings = value.filter((entry) => typeof entry === "string") as string[];
-  return strings.length > 0 ? strings : [];
+  return strings.length > 0 ? strings : null;
 }
 
 function toRegexList(patterns: string[]): RegExp[] {


### PR DESCRIPTION
## Summary
- Fix repeated-spacing options fallback and test coverage.

## Changes
- Ensure allow-patterns falls back to defaults when empty.
- Use a real newline in the allow-after-line-start test fixture.

## Testing
- bun test
