### PR TITLE
test: add glob parity harness case

### DIFF
--- a/harness/suites/mutations/glob-parity/command.json
+++ b/harness/suites/mutations/glob-parity/command.json
@@ -1,0 +1,12 @@
+{
+  "cmd": "bun",
+  "args": [
+    "harness/utils/lint-runner.ts",
+    "--config",
+    "north/north.config.yaml",
+    "--files",
+    "fixtures/harness/app/[slug]/page.tsx",
+    "--files",
+    "fixtures/harness/glob/*.tsx"
+  ]
+}

--- a/harness/suites/mutations/glob-parity/expect.json
+++ b/harness/suites/mutations/glob-parity/expect.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "north/no-raw-palette": 1,
+    "north/no-arbitrary-values": 1
+  }
+}

--- a/harness/suites/mutations/glob-parity/patch.diff
+++ b/harness/suites/mutations/glob-parity/patch.diff
@@ -1,0 +1,19 @@
+diff --git a/fixtures/harness/app/[slug]/page.tsx b/fixtures/harness/app/[slug]/page.tsx
+new file mode 100644
+index 0000000..5c49e0a
+--- /dev/null
++++ b/fixtures/harness/app/[slug]/page.tsx
+@@ -0,0 +1,3 @@
++export function Page() {
++  return <div className="bg-blue-500">Page</div>;
++}
+
+diff --git a/fixtures/harness/glob/subject.tsx b/fixtures/harness/glob/subject.tsx
+new file mode 100644
+index 0000000..c4cf3f7
+--- /dev/null
++++ b/fixtures/harness/glob/subject.tsx
+@@ -0,0 +1,3 @@
++export function Subject() {
++  return <div className="p-[13px]">Subject</div>;
++}

--- a/harness/utils/lint-runner.ts
+++ b/harness/utils/lint-runner.ts
@@ -1,0 +1,68 @@
+import { runLint } from "../../packages/north/src/lint/engine.ts";
+
+interface ParsedArgs {
+  configPath?: string;
+  cwd?: string;
+  files: string[];
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { files: [] };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--config" || arg === "-c") {
+      const value = args[i + 1];
+      if (value !== undefined) {
+        parsed.configPath = value;
+        i += 1;
+      }
+    } else if (arg === "--cwd") {
+      const value = args[i + 1];
+      if (value !== undefined) {
+        parsed.cwd = value;
+        i += 1;
+      }
+    } else if (arg === "--files" || arg === "-f") {
+      const value = args[i + 1];
+      if (value !== undefined) {
+        parsed.files.push(value);
+        i += 1;
+      }
+    }
+  }
+
+  return parsed;
+}
+
+async function run() {
+  const { configPath, cwd, files } = parseArgs(process.argv.slice(2));
+
+  if (!configPath) {
+    console.error("Missing --config <path> argument.");
+    process.exit(1);
+  }
+
+  const { report } = await runLint({
+    cwd: cwd ?? process.cwd(),
+    configPath,
+    files: files.length > 0 ? files : undefined,
+  });
+
+  const serializableReport = {
+    summary: report.summary,
+    violations: report.issues,
+    stats: report.stats,
+    rules: report.rules.map((rule) => ({
+      ...rule,
+      regex: rule.regex ? rule.regex.source : undefined,
+    })),
+  };
+
+  console.log(JSON.stringify(serializableReport, null, 2));
+}
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add glob parity coverage via a custom mutation command.

## Changes
- Allow mutation suites to define a custom command runner.
- Add a lint-runner script for file-patterned lint runs.
- Add glob-parity mutation patch + expectation + command config.

## Testing
- bun test
