### PR TITLE
feat(mcp): dynamic tool updates

### DIFF
--- a/packages/north/src/mcp/server.test.ts
+++ b/packages/north/src/mcp/server.test.ts
@@ -167,7 +167,7 @@ describe("tool registration completeness", () => {
       }
 
       // Check if function is called: registerFoo(server)
-      const callPattern = new RegExp(`\\b${fn}\\s*\\(\\s*server\\s*\\)`);
+      const callPattern = new RegExp(`\\b${fn}\\s*\\(\\s*server\\b`);
       if (!callPattern.test(serverContent)) {
         missingCalls.push(`${fn} (from ${file})`);
       }

--- a/packages/north/src/mcp/server.ts
+++ b/packages/north/src/mcp/server.ts
@@ -302,7 +302,7 @@ export function createServerWithTools(): {
     if (stateChanged) {
       currentState = nextState;
       const toolsChanged = applyToolState(registry, nextState);
-      if (!toolsChanged && options.forceNotify) {
+      if (toolsChanged || options.forceNotify) {
         server.sendToolListChanged();
       }
       return currentState;

--- a/packages/north/src/mcp/tools/adopt-tool.ts
+++ b/packages/north/src/mcp/tools/adopt-tool.ts
@@ -9,7 +9,7 @@
  * @see .scratch/mcp-server/13-cli-adopt-spec.md for CLI specification
  */
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type AdoptReport, adopt } from "../../commands/adopt.ts";
 import { detectContext } from "../state.ts";
@@ -206,8 +206,8 @@ export async function executeAdoptTool(
  *
  * This is a Tier 3 tool - requires index (.north/state/index.db) to be present.
  */
-export function registerAdoptTool(server: McpServer): void {
-  server.registerTool(
+export function registerAdoptTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_adopt",
     {
       description:

--- a/packages/north/src/mcp/tools/check.ts
+++ b/packages/north/src/mcp/tools/check.ts
@@ -13,7 +13,7 @@
 
 import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { runLint } from "../../lint/engine.ts";
 import type { LintIssue, LintStats, LintSummary } from "../../lint/types.ts";
@@ -354,8 +354,8 @@ export async function executeCheckTool(
  *
  * This is a Tier 2 tool - requires config (.north/config.yaml) to be present.
  */
-export function registerCheckTool(server: McpServer): void {
-  server.registerTool(
+export function registerCheckTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_check",
     {
       description:

--- a/packages/north/src/mcp/tools/classify-tool.ts
+++ b/packages/north/src/mcp/tools/classify-tool.ts
@@ -11,7 +11,7 @@
  * @issue #87 (partial)
  */
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type ClassifyReport, classify } from "../../commands/classify.ts";
 import { type IndexDatabase, openIndexDatabase } from "../../index/db.ts";
@@ -189,8 +189,8 @@ export async function executeClassifyTool(
  *
  * This is a Tier 3 tool - requires index (.north/state/index.db) to be present.
  */
-export function registerClassifyTool(server: McpServer): void {
-  server.registerTool(
+export function registerClassifyTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_classify",
     {
       description:

--- a/packages/north/src/mcp/tools/context.ts
+++ b/packages/north/src/mcp/tools/context.ts
@@ -8,7 +8,7 @@
  */
 
 import { access } from "node:fs/promises";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { resolveNorthPaths } from "../../config/env.ts";
 import { loadConfig } from "../../config/loader.ts";
@@ -223,8 +223,8 @@ export async function executeContextTool(
  *
  * This is a Tier 2 tool - requires config (.north/config.yaml) to be present.
  */
-export function registerContextTool(server: McpServer): void {
-  server.registerTool(
+export function registerContextTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_context",
     {
       description:

--- a/packages/north/src/mcp/tools/discover.ts
+++ b/packages/north/src/mcp/tools/discover.ts
@@ -7,7 +7,7 @@
  * This is a Tier 3 tool - requires index (.north/state/index.db) to be present.
  */
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type IndexDatabase, openIndexDatabase } from "../../index/db.ts";
 import { checkIndexFresh, getIndexStatus } from "../../index/queries.ts";
@@ -795,8 +795,8 @@ function createDiscoverHandler() {
  *
  * This is a Tier 3 tool - requires index (.north/state/index.db) to be present.
  */
-export function registerDiscoverTool(server: McpServer): void {
-  server.registerTool(
+export function registerDiscoverTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_discover",
     {
       description: DISCOVER_DESCRIPTION,
@@ -809,8 +809,8 @@ export function registerDiscoverTool(server: McpServer): void {
  * Register the north_find alias for north_discover.
  * This matches the 'north find' CLI command for discoverability.
  */
-export function registerDiscoverAlias(server: McpServer): void {
-  server.registerTool(
+export function registerDiscoverAlias(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_find",
     {
       description: `${DISCOVER_DESCRIPTION} (Alias for north_discover, matches 'north find' CLI command.)`,

--- a/packages/north/src/mcp/tools/index-tool.ts
+++ b/packages/north/src/mcp/tools/index-tool.ts
@@ -11,7 +11,7 @@
  * @issue #85
  */
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { buildIndex } from "../../index/build.ts";
 import { checkIndexFresh, getIndexStatus } from "../../index/queries.ts";
@@ -140,8 +140,8 @@ export async function executeIndexTool(
  * This is a Tier 2 tool - requires config (.north/config.yaml) to be present,
  * but does not require an existing index since it creates one.
  */
-export function registerIndexTool(server: McpServer): void {
-  server.registerTool(
+export function registerIndexTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_index",
     {
       description:

--- a/packages/north/src/mcp/tools/migrate-tool.ts
+++ b/packages/north/src/mcp/tools/migrate-tool.ts
@@ -9,7 +9,7 @@
  * @see .scratch/mcp-server/15-cli-migrate-spec.md for CLI specification
  */
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type MigrateReport, migrate } from "../../commands/migrate.ts";
 import { resolveSafeMode } from "../../core/safe-mode.ts";
@@ -220,8 +220,8 @@ export async function executeMigrateTool(
  *
  * This is a Tier 2 tool - requires config (.north/config.yaml) to be present.
  */
-export function registerMigrateTool(server: McpServer): void {
-  server.registerTool(
+export function registerMigrateTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_migrate",
     {
       description:

--- a/packages/north/src/mcp/tools/promote.ts
+++ b/packages/north/src/mcp/tools/promote.ts
@@ -7,7 +7,7 @@
  * This is a Tier 3 tool - requires index (.north/state/index.db) to be present.
  */
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type IndexDatabase, openIndexDatabase } from "../../index/db.ts";
 import { checkIndexFresh, getIndexStatus } from "../../index/queries.ts";
@@ -520,8 +520,8 @@ export async function executePromoteTool(
  *
  * This is a Tier 3 tool - requires index (.north/state/index.db) to be present.
  */
-export function registerPromoteTool(server: McpServer): void {
-  server.registerTool(
+export function registerPromoteTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_promote",
     {
       description:

--- a/packages/north/src/mcp/tools/propose-tool.ts
+++ b/packages/north/src/mcp/tools/propose-tool.ts
@@ -9,7 +9,7 @@
  * @see .scratch/mcp-server/14-cli-propose-spec.md for CLI specification
  */
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type ProposeReport, propose } from "../../commands/propose.ts";
 import { detectContext } from "../state.ts";
@@ -212,8 +212,8 @@ export async function executeProposeTool(
  *
  * This is a Tier 2 tool - requires config (.north/config.yaml) to be present.
  */
-export function registerProposeTool(server: McpServer): void {
-  server.registerTool(
+export function registerProposeTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_propose",
     {
       description:

--- a/packages/north/src/mcp/tools/query.ts
+++ b/packages/north/src/mcp/tools/query.ts
@@ -8,7 +8,7 @@
  * @issue #83
  */
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type IndexDatabase, openIndexDatabase } from "../../index/db.ts";
 import { checkIndexFresh, getIndexStatus } from "../../index/queries.ts";
@@ -389,8 +389,8 @@ export async function executeQueryTool(
  *
  * This is a Tier 3 tool - requires index (.north/state/index.db) to be present.
  */
-export function registerQueryTool(server: McpServer): void {
-  server.registerTool(
+export function registerQueryTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_query",
     {
       description:

--- a/packages/north/src/mcp/tools/refactor.ts
+++ b/packages/north/src/mcp/tools/refactor.ts
@@ -7,7 +7,7 @@
  * This is a Tier 3 tool - requires index (.north/state/index.db) to be present.
  */
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { runLint } from "../../lint/engine.ts";
 import type { LintIssue, RuleSeverity } from "../../lint/types.ts";
@@ -331,8 +331,8 @@ export async function executeRefactorTool(
  *
  * This is a Tier 3 tool - requires index (.north/state/index.db) to be present.
  */
-export function registerRefactorTool(server: McpServer): void {
-  server.registerTool(
+export function registerRefactorTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_refactor",
     {
       description:

--- a/packages/north/src/mcp/tools/suggest.ts
+++ b/packages/north/src/mcp/tools/suggest.ts
@@ -12,7 +12,7 @@
 
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { DEFAULT_COLORS_LIGHT } from "../../config/defaults.ts";
 import { loadConfig } from "../../config/loader.ts";
@@ -468,8 +468,8 @@ export async function executeSuggestTool(
  *
  * This is a Tier 2 tool - requires config (.north/config.yaml) to be present.
  */
-export function registerSuggestTool(server: McpServer): void {
-  server.registerTool(
+export function registerSuggestTool(server: McpServer): RegisteredTool {
+  return server.registerTool(
     "north_suggest",
     {
       description:


### PR DESCRIPTION
## Summary
- Dynamically enable/disable MCP tools based on detected project state (none/config/indexed)
- `north_status` refresh re-detects state and can trigger `tools/list_changed`
- Server performs initial state detection after connect and updates tool availability
- `north_status` now returns `lockedTools` with reasons for unavailable tools

Resolves #74

## Testing
- `bun test` (turbo, via lefthook pre-push)
