### PR TITLE
fix(mcp): notify on tool state change

### DIFF
--- a/packages/north/src/mcp/server.ts
+++ b/packages/north/src/mcp/server.ts
@@ -302,7 +302,7 @@ export function createServerWithTools(): {
     if (stateChanged) {
       currentState = nextState;
       const toolsChanged = applyToolState(registry, nextState);
-      if (!toolsChanged && options.forceNotify) {
+      if (toolsChanged || options.forceNotify) {
         server.sendToolListChanged();
       }
       return currentState;


### PR DESCRIPTION
## Summary
- Notify clients whenever tool availability changes after state transitions
- Ensure `tools/list_changed` fires on both state changes and explicit refreshes

## Testing
- `bun test` (turbo, via lefthook pre-push)

Resolves #74
